### PR TITLE
only log Django messages to console

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -158,7 +158,7 @@ LOGGING = {
         },
     },
     'loggers': {
-        '': {
+        'django': {
             'handlers': ['console'],
             'level': 'DEBUG',
         },


### PR DESCRIPTION
Closes #79 .

Due to an issue in downstream libraries, we are getting weird logging messages printed to ipython when trying to autocomplete. With this change we will only print Django errors in the console, rather than all printing all python errors.