### PR TITLE
Fix animal creation for owner SR workflow

### DIFF
--- a/frontend/src/hotline/ServiceRequestForm.js
+++ b/frontend/src/hotline/ServiceRequestForm.js
@@ -121,8 +121,12 @@ function ServiceRequestForm(props) {
             .then(response => {
               props.state.steps.animals.forEach(animal => {
                 // Add owner and reporter to animal data.
-                animal.append('reporter', reporterResponse[0].data.id);
-                animal.append('new_owner', ownerResponse[0].data.id);
+                if (reporterResponse[0].data.id) {
+                  animal.append('reporter', reporterResponse[0].data.id);
+                }
+                if (ownerResponse[0].data.id) {
+                  animal.append('new_owner', ownerResponse[0].data.id);
+                }
                 animal.append('request', response.data.id);
                 axios.post('/animals/api/animal/', animal)
                 .catch(error => {


### PR DESCRIPTION
Animals weren't being created as part of the SR workflow. When running the owner calling workflow, we were submitting `null` for the `reporter` when creating the Animal objects and Django barfed. Ugly if logic to get around this.