### PR TITLE
Locking Django Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 apig-wsgi
 awscli
 boto3
-Django>=3.1
+Django==3.1
 django-activity-stream
 django-cors-headers
 django-filter


### PR DESCRIPTION
Seems like there is some incapability when Django was rolled to a new release.  Going to lock at 3.1 for now to fix test suite.