### PR TITLE
adds printable intake summary on click to owner details #404

### DIFF
--- a/animals/serializers.py
+++ b/animals/serializers.py
@@ -16,10 +16,11 @@ class ModestAnimalSerializer(SimpleAnimalSerializer):
     front_image = serializers.SerializerMethodField()
     side_image = serializers.SerializerMethodField()
     owner_names = serializers.StringRelatedField(source='owners', many=True, read_only=True)
+    shelter_object = SimpleShelterSerializer(source='shelter', required=False, read_only=True)
 
     class Meta:
         model = Animal
-        fields = ['id', 'name', 'species', 'aggressive', 'request', 'shelter', 'status', 'aco_required', 'color_notes', 'front_image', 'side_image', 'owner_names']
+        fields = ['id', 'name', 'species', 'aggressive', 'request', 'shelter_object', 'shelter', 'status', 'aco_required', 'color_notes', 'front_image', 'side_image', 'owner_names']
 
     def get_front_image(self, obj):
         try:

--- a/frontend/src/components/Utils.js
+++ b/frontend/src/components/Utils.js
@@ -1,6 +1,5 @@
+import { capitalize } from '../utils/formatString';
+
 export function titleCase(str) {
-    str = str.toLowerCase().split(' ').map(function(word) {
-        return (word.charAt(0).toUpperCase() + word.slice(1));
-    }).join(' ');
-    return str;
+    return capitalize(str, { proper: true });
 };

--- a/frontend/src/components/__tests__/Utils.test.js
+++ b/frontend/src/components/__tests__/Utils.test.js
@@ -1,0 +1,11 @@
+import { titleCase } from '../Utils';
+
+describe('Components > Utils > titleCase', () => {
+  const mockStringInput = 'capitalize every word.';
+
+  const mockStringOutput = 'Capitalize Every Word.';
+
+  it('capitalizes the first letter of the first word', () => {
+    expect(titleCase(mockStringInput)).toEqual(mockStringOutput);
+  });
+})

--- a/frontend/src/dispatch/Utils.js
+++ b/frontend/src/dispatch/Utils.js
@@ -1,4 +1,3 @@
-
 import ShelterlyPDF from '../utils/pdf';
 import { priorityChoices } from '../constants';
 import { dispatchStatusChoices } from '../animals/constants';
@@ -180,12 +179,11 @@ export const printDispatchResolutionForm = (data) => {
       });
       pdf.drawWrappedText({
         text: `Description: ${animal.color_notes || 'N/A'}`,
-        linePadding: -5,
         bottomPadding: 5
       });
       pdf.drawWrappedText({
         text: `Behavior: ${animal.behavior_notes || 'N/A'}`,
-        linePadding: -5
+        linePadding: -10
       });
 
       pdf.drawHRule({ buffer: 15 });

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -6,12 +6,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faEdit, faPlusSquare, faUserPlus
 } from '@fortawesome/free-solid-svg-icons';
-import { faHomeHeart, faPhonePlus } from '@fortawesome/pro-solid-svg-icons';
+import { faHomeHeart, faPhonePlus, faPrint } from '@fortawesome/pro-solid-svg-icons';
 import Moment from 'react-moment';
 import Header from '../components/Header';
 import History from '../components/History';
 import Scrollbar from '../components/Scrollbars';
 import AnimalCards from '../components/AnimalCards';
+import { printOwnerDetails } from './Utils';
 
 function PersonDetails({id}) {
 
@@ -49,6 +50,13 @@ function PersonDetails({id}) {
     owner_contacts: [],
     action_history: [],
   });
+
+  const handleDownloadPdfClick = (e) => {
+    e.preventDefault();
+
+    printOwnerDetails(data);
+  }
+
 
   // Hook for initializing data.
   useEffect(() => {
@@ -108,6 +116,21 @@ function PersonDetails({id}) {
           </OverlayTrigger>
         </span>
       }
+      <OverlayTrigger
+        key={"offline-dispatch-assignment"}
+        placement="bottom"
+        overlay={
+          <Tooltip id={`tooltip-offline-dispatch-assignment`}>
+            Download printable Intake Summary
+          </Tooltip>
+        }
+      >
+        {({ ref, ...triggerHandler }) => (
+          <Link onClick={handleDownloadPdfClick} {...triggerHandler} href="#">
+            <span ref={ref}><FontAwesomeIcon icon={faPrint} className="ml-3"  inverse /></span>
+          </Link>
+        )}
+      </OverlayTrigger>
     </Header>
     <hr/>
     <div className="row">

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -98,7 +98,7 @@ function PersonDetails({id}) {
               </Tooltip>
             }
           >
-            <Link href={"/people/owner/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-1 mr-1" inverse /></Link>
+            <Link href={"/people/owner/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse /></Link>
           </OverlayTrigger>
         </span>
       :
@@ -112,7 +112,7 @@ function PersonDetails({id}) {
               </Tooltip>
             }
           >
-            <Link href={"/people/reporter/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-1" inverse /></Link>
+            <Link href={"/people/reporter/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse /></Link>
           </OverlayTrigger>
         </span>
       }
@@ -127,7 +127,7 @@ function PersonDetails({id}) {
       >
         {({ ref, ...triggerHandler }) => (
           <Link onClick={handleDownloadPdfClick} {...triggerHandler} href="#">
-            <span ref={ref}><FontAwesomeIcon icon={faPrint} className="ml-3"  inverse /></span>
+            <span ref={ref}><FontAwesomeIcon icon={faPrint} className="ml-1"  inverse /></span>
           </Link>
         )}
       </OverlayTrigger>

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -117,11 +117,11 @@ function PersonDetails({id}) {
         </span>
       }
       <OverlayTrigger
-        key={"offline-dispatch-assignment"}
+        key={"offline-owner-summary"}
         placement="bottom"
         overlay={
-          <Tooltip id={`tooltip-offline-dispatch-assignment`}>
-            Download printable Intake Summary
+          <Tooltip id={`tooltip-offline-owner-summary`}>
+            Download printable Owner Summary
           </Tooltip>
         }
       >

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -3,17 +3,17 @@ import { capitalize } from '../utils/formatString';
 
 export const printOwnerDetails = (owner) => {
   const pdf = new ShelterlyPDF();
-  pdf.fileName = `Intake-Summary-${owner.id.toString().padStart(3, 0)}`;
+  pdf.fileName = `Owner-Summary-${owner.id.toString().padStart(3, 0)}`;
 
   // draw page header
   pdf.drawPageHeader({
-    text: 'Intake Summary',
+    text: 'Owner Summary',
     subText: `Date: ${new Date().toLocaleDateString()}`
   });
   pdf.drawHRule();
 
   // draw owner section
-  pdf.drawSectionHeader({ text: 'Owner Details', hRule: false });
+  pdf.drawSectionHeader({ text: 'Owner Details', hRule: true });
   
   const ownerInfoList = [`Name: ${owner.first_name} ${owner.last_name}`];
   if (owner.agency) ownerInfoList.push(`Agency: ${owner.agency}`);
@@ -52,11 +52,12 @@ export const printOwnerDetails = (owner) => {
 
     const animalInfoList = [
       `ID: A#${animal.id}`,
+      `Status: ${animal.status}`,
       `Name: ${animal.name || 'Unknown'}`,
-      `Species: ${animal.species}`,
-      `Sex: ${animal.sex || 'Unknown'}`,
-      `Age: ${animal.age || 'Unknown'}`,
-      `Size: ${animal.size || 'Unknown'}`,
+      `Species: ${capitalize(animal.species)}`,
+      `Sex: ${capitalize(animal.sex|| 'Unknown')}`,
+      `Age: ${capitalize(animal.age || 'Unknown')}`,
+      `Size: ${capitalize(animal.size || 'Unknown')}`,
       `Primary Color: ${capitalize(animal.pcolor || 'N/A')}`,
       `Secondary Color: ${capitalize(animal.scolor || 'N/A')}`
     ];
@@ -83,8 +84,9 @@ export const printOwnerDetails = (owner) => {
       })
     }
 
-    pdf.drawHRule({ buffer: 15 });
-    lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+    pdf.drawPad(5);
+    pdf.drawHRule();
+    lastYPosAfterDraw = pdf.getLastYPositionWithBuffer();
 
     // If after draw y position is less than before draw, that means there was a page break.
     // Draw the animal header again.

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -19,7 +19,7 @@ export const printOwnerDetails = (owner) => {
   if (owner.agency) ownerInfoList.push(`Agency: ${owner.agency}`);
   if (owner.phone) ownerInfoList.push(`Telephone: ${owner.display_phone} ${owner.display_alt_phone ? `  Alt: ${owner.display_alt_phone}` : ''}`);
   if (owner.email) ownerInfoList.push(`Email: ${owner.email}`);
-  if (owner.request) ownerInfoList.push(`ServiceRequest: ${owner.request.full_address}`);
+  if (owner.request) ownerInfoList.push(`Service Request: ${owner.request.full_address}`);
   else {
     if (owner.address) ownerInfoList.push(`Address: ${owner.full_address}`);
     else ownerInfoList.push('Address: No Address Listed');
@@ -52,7 +52,7 @@ export const printOwnerDetails = (owner) => {
 
     const animalInfoList = [
       `ID: A#${animal.id}`,
-      `Status: ${animal.status}`,
+      `Status: ${capitalize(animal.status.toLowerCase(), { proper: true })}`,
       `Name: ${animal.name || 'Unknown'}`,
       `Species: ${capitalize(animal.species)}`,
       `Sex: ${capitalize(animal.sex|| 'Unknown')}`,

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -1,0 +1,97 @@
+import ShelterlyPDF from '../utils/pdf';
+import { capitalize } from '../utils/formatString';
+
+export const printOwnerDetails = (owner) => {
+  const pdf = new ShelterlyPDF();
+  pdf.fileName = `Intake-Summary-${owner.id.toString().padStart(3, 0)}`;
+
+  // draw page header
+  pdf.drawPageHeader({
+    text: 'Intake Summary',
+    subText: `Date: ${new Date().toLocaleDateString()}`
+  });
+  pdf.drawHRule();
+
+  // draw owner section
+  pdf.drawSectionHeader({ text: 'Owner Details', hRule: false });
+  
+  const ownerInfoList = [`Name: ${owner.first_name} ${owner.last_name}`];
+  if (owner.agency) ownerInfoList.push(`Agency: ${owner.agency}`);
+  if (owner.phone) ownerInfoList.push(`Telephone: ${owner.display_phone} ${owner.display_alt_phone ? `  Alt: ${owner.display_alt_phone}` : ''}`);
+  if (owner.email) ownerInfoList.push(`Email: ${owner.email}`);
+  if (owner.request) ownerInfoList.push(`ServiceRequest: ${owner.request.full_address}`);
+  else {
+    if (owner.address) ownerInfoList.push(`Address: ${owner.full_address}`);
+    else ownerInfoList.push('Address: No Address Listed');
+  }
+
+  pdf.drawTextList({
+    labels: ownerInfoList,
+    bottomPadding: 15
+  });
+
+  if (owner.comments) {
+    pdf.drawWrappedText({
+      text: `Comments: ${owner.comments}`
+    })
+  }
+
+  pdf.drawPad();
+
+  function drawAnimalHeader() {
+    pdf.drawSectionHeader({ text: 'Animals', hRule: true });
+  }
+
+  drawAnimalHeader();
+
+  // keep the last y position after a row was drawn
+  let lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+  owner.animals.forEach((animal) => {
+    // grab the last y position before we draw a row
+    const lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+
+    const animalInfoList = [
+      `ID: A#${animal.id}`,
+      `Name: ${animal.name || 'Unknown'}`,
+      `Species: ${animal.species}`,
+      `Sex: ${animal.sex || 'Unknown'}`,
+      `Age: ${animal.age || 'Unknown'}`,
+      `Size: ${animal.size || 'Unknown'}`,
+      `Primary Color: ${capitalize(animal.pcolor || 'N/A')}`,
+      `Secondary Color: ${capitalize(animal.scolor || 'N/A')}`
+    ];
+
+    pdf.drawTextList({
+      labels: animalInfoList,
+      listStyle: 'grid',
+      bottomPadding: 0
+    });
+
+    pdf.drawPad();
+
+    if (animal.color_notes) {
+      pdf.drawWrappedText({
+        text: `Breed / Description: ${animal.color_notes}`,
+        linePadding: -5
+      });
+    }
+
+    if (animal.shelter) {
+      pdf.drawWrappedText({
+        text: `Shelter Address: ${animal.shelter_object?.full_address || 'Unknown'}`,
+        linePadding: 5
+      })
+    }
+
+    pdf.drawHRule({ buffer: 15 });
+    lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+
+    // If after draw y position is less than before draw, that means there was a page break.
+    // Draw the animal header again.
+    if (lastYPosAfterDraw < lastYPosBeforeDraw) {
+      drawAnimalHeader();
+    }
+  });
+
+  pdf.saveFile();
+};

--- a/frontend/src/utils/__tests__/formatString.test.js
+++ b/frontend/src/utils/__tests__/formatString.test.js
@@ -1,0 +1,19 @@
+import { capitalize } from '../formatString';
+
+describe('Utils > formatString', () => {
+  const mockStringInput1 = 'capitalize the first word.';
+  const mockStringInput2 = 'capitalize every word.';
+
+  const expectedStringOutput1 = 'Capitalize the first word.';
+  const expectedStringOutput2 = 'Capitalize Every Word.';
+
+  it('capitalizes the first letter of the first word', () => {
+    expect(capitalize(mockStringInput1)).toEqual(expectedStringOutput1);
+  });
+
+  it('capitalizes the first letter of every word', () => {
+    expect(capitalize(mockStringInput2, {
+      proper: true
+    })).toEqual(expectedStringOutput2)
+  })
+})

--- a/frontend/src/utils/formatString.js
+++ b/frontend/src/utils/formatString.js
@@ -1,0 +1,18 @@
+export function capitalize(stringToCapitalize, {
+  proper = false
+} = {}) {
+  function capitalizeWord(word) {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  }
+
+  if (proper) {
+    const words = stringToCapitalize.split(' ');
+    for(let i = 0; i < words.length; i++) {
+      words[i] = capitalizeWord(words[i])
+    }
+
+    return words.join(' ');
+  }
+
+  return capitalizeWord(stringToCapitalize);
+}

--- a/frontend/src/utils/formatString.js
+++ b/frontend/src/utils/formatString.js
@@ -1,3 +1,9 @@
+/**
+ * capitalizes the first character of the first word, or all words in a string
+ * @param  {string} stringToCapitalize
+ * @param  {object} [options] - optional configuration options
+ * @param  {boolean} [options.proper] - proper noun capitalization if true
+ */
 export function capitalize(stringToCapitalize, {
   proper = false
 } = {}) {

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -179,7 +179,7 @@ class ShelterlyPDF {
   }
 
   drawSingleLineText({ text, bottomPadding = 0, topPadding = 0 }) {
-    let yPosition = this.getLastYPositionWithBuffer() + topPadding;
+    let yPosition = this.beforeDraw({ yPosition: this.getLastYPositionWithBuffer({ buffer: this.#defaultElementBuffer + topPadding }) }); // this.getLastYPositionWithBuffer() + topPadding;
     this.#jsPDF.text(text, this.#documentLeftMargin, yPosition)
     this.#documentLastYPosition = yPosition + bottomPadding;
   }

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -300,6 +300,7 @@ class ShelterlyPDF {
         }
 
         if (i === listItems.length - 1) {
+          this.#documentLeftMargin = this.#defaultXMargin;
           this.#documentLastYPosition = this.beforeDraw({ yPosition }) + size + bottomPadding;
         }
       }


### PR DESCRIPTION
Added the button to download a printable intake summary from the owner details screen, see attached pdf of an example of what that looks like (from my local environment). Let me know of any changes and i'll work it in.

[Intake-Summary-022 (32).pdf](https://github.com/trevorskaggs/shelterly/files/8748272/Intake-Summary-022.32.pdf)

Additionally, I've included the shelter_object to the ModestAnimalSerializer class, which  will have performance implications. The measure of those implications I don't know, but it's worth taking a gander at some point I'm sure instead of continuing to include fields like this down the road. At what point would it be a better remeasure to create a new serializer, or optional include?

Closes #404 