### PR TITLE
Adds print all buttons to all searchable pages

### DIFF
--- a/frontend/src/animals/AnimalSearch.js
+++ b/frontend/src/animals/AnimalSearch.js
@@ -15,7 +15,7 @@ import Moment from 'react-moment';
 import Select, { components } from 'react-select';
 import L from "leaflet";
 import { Circle, Map, Marker, Tooltip as MapTooltip, TileLayer } from "react-leaflet";
-import { useMark } from '../hooks';
+import { useMark, useSubmitting } from '../hooks';
 import Header from '../components/Header';
 import Scrollbar from '../components/Scrollbars';
 import { titleCase } from '../components/Utils';
@@ -25,6 +25,7 @@ import { catColorChoices, dogColorChoices, horseColorChoices, otherColorChoices,
 import AnimalCoverImage from '../components/AnimalCoverImage';
 import { printAnimalCareSchedule, printAllAnimalCareSchedules } from './Utils';
 import { SystemErrorContext } from '../components/SystemError';
+import ButtonSpinner from '../components/ButtonSpinner';
 
 const NoOptionsMessage = props => {
   return (
@@ -81,6 +82,12 @@ function AnimalSearch({ incident }) {
   const [page, setPage] = useState(1);
   const [numPages, setNumPages] = useState(1);
   const { markInstances } = useMark();
+  const {
+    isSubmitting,
+    handleSubmitting,
+    submittingComplete,
+    submittingLabel
+  } = useSubmitting();
 
   const colorChoices = {'':[], 'dog':dogColorChoices, 'cat':catColorChoices, 'horse':horseColorChoices, 'other':otherColorChoices}
 
@@ -139,7 +146,9 @@ function AnimalSearch({ incident }) {
   const handlePrintAllClick = (e) => {
     e.preventDefault();
 
-    printAllAnimalCareSchedules(animals);
+    handleSubmitting()
+      .then(() => printAllAnimalCareSchedules(animals))
+      .then(submittingComplete);
   }
 
   function setFocus(pageNum) {
@@ -291,10 +300,16 @@ function AnimalSearch({ incident }) {
             <Button variant="outline-light" type="submit" style={{borderRadius:"0 5px 5px 0"}}>Search</Button>
           </InputGroup.Append>
           <Button variant="outline-light" className="ml-1" onClick={handleShowFilters}>Advanced {showFilters ? <FontAwesomeIcon icon={faChevronDoubleUp} size="sm" /> : <FontAwesomeIcon icon={faChevronDoubleDown} size="sm" />}</Button>
-          <Button variant="outline-light" className="ml-1" onClick={handlePrintAllClick}>
+          <ButtonSpinner
+            variant="outline-light"
+            className="ml-1"
+            onClick={handlePrintAllClick}
+            isSubmitting={isSubmitting}
+            isSubmittingText={submittingLabel}
+          >
             Print All ({`${animals.length}`})
             <FontAwesomeIcon icon={faPrint} className="ml-2 text-light" inverse />
-          </Button>
+          </ButtonSpinner>
         </InputGroup>
         <Collapse in={showFilters}>
           <div>

--- a/frontend/src/animals/Utils.js
+++ b/frontend/src/animals/Utils.js
@@ -57,10 +57,18 @@ async function buildAnimalCareScheduleDoc (animals) {
         `Intake Date: ${animal.intake_date
           ? new Date(animal.intake_date).toLocaleDateString()
           : 'N/A'}`,
-        `Location: ${animal.room ? `${animal.building_name} / ${animal.room_name}` : 'N/A'}`
+          `Species: ${capitalize(animal.species)}`
       ],
-      [`Species: ${capitalize(animal.species)}`, `Color: ${capitalize(animal.pcolor)} ${animal.scolor ? `/ ${capitalize(animal.scolor)}` : '' }`],
-      [`Age: ${capitalize(animal.age)}`, `Under Vet Care: Y / N`]
+      [
+        `Color: ${capitalize(animal.pcolor)} ${animal.scolor ? `/ ${capitalize(animal.scolor)}` : '' }`,
+        `Age: ${capitalize(animal.age)}`
+      ],
+      [
+        `Under Vet Care: Y / N`,
+        animal.shelter_object
+          ? ''
+          : 'Location: N/A'
+      ]
     ];
     const listOptions = {
       listStyle: 'inline',
@@ -73,9 +81,23 @@ async function buildAnimalCareScheduleDoc (animals) {
     pdf.resetDocumentLeftMargin();
     pdf.drawPad(15);
 
+    if (animal.shelter_object) {
+      pdf.drawWrappedText({
+        text: `Location: ${
+          animal.room
+            ? `${animal.building_name} / ${animal.room_name} /`
+            : animal.building_name ? `${animal.building_name} /` : ''
+        }${
+          animal.shelter_object
+            ? `${animal.shelter_object.name || ''} ${animal.shelter_object.full_address || ''} `
+            : ''
+        }`
+      })
+    }
+
     if (animal.owners && animal.owners.length) {
       pdf.drawWrappedText({ text: `Owner(s): ${animal.owners.map((owner) =>
-        `${capitalize(`${owner.first_name} ${owner.last_name}`, { proper: true })} ${owner.display_phone}`).join('; ')}`})
+        `${capitalize(`${owner.first_name} ${owner.last_name}`, { proper: true })}`).join('; ')}`})
     }
     else if (animal.owner_names && animal.owner_names.length) {
         pdf.drawWrappedText({ text: `Owner(s): ${animal.owner_names.map((owner_name) =>
@@ -120,8 +142,12 @@ async function buildAnimalCareScheduleDoc (animals) {
       buffer: 5
     });
 
+    const pageWidth = pdf.pageWidth - 30;
+    const smallCol = pageWidth * .15;
+    const bigCol = pageWidth * .35;
     pdf.drawTableGrid({
-      headers: ['Date Time', 'AR#', 'Actions', 'Comments']
+      headers: ['Date Time', 'AR#', 'Actions', 'Comments'],
+      columnStyles: [{ cellWidth: smallCol }, { cellWidth: smallCol }, { cellWidth: bigCol }, { cellWidth: bigCol }]
     });
   }
 
@@ -131,13 +157,13 @@ async function buildAnimalCareScheduleDoc (animals) {
 async function printAnimalCareSchedule (animal = {}) {
   const pdf = await buildAnimalCareScheduleDoc([animal]);
   pdf.fileName = pdf.filename || `Shelterly-Animal-Care-Schedule-${animal.id.toString().padStart(3, 0)}-${moment().format(dateFormat)}`;
-  pdf.saveFile();
+  return pdf.saveFile();
 };
 
 async function printAllAnimalCareSchedules (animals = []) {
   const  pdf = await buildAnimalCareScheduleDoc(animals);
   pdf.fileName = `Shelterly-Animal-Care-Schedules-${moment().format(dateFormat)}`;
-  pdf.saveFile();
+  return pdf.saveFile();
 }
 
 export {

--- a/frontend/src/animals/Utils.js
+++ b/frontend/src/animals/Utils.js
@@ -84,14 +84,12 @@ async function buildAnimalCareScheduleDoc (animals) {
     if (animal.shelter_object) {
       pdf.drawWrappedText({
         text: `Location: ${
-          animal.room
-            ? `${animal.building_name} / ${animal.room_name} /`
-            : animal.building_name ? `${animal.building_name} /` : ''
+          animal.shelter_object ? `${animal.shelter_object.name}` : "N/A"
         }${
-          animal.shelter_object
-            ? `${animal.shelter_object.name || ''} ${animal.shelter_object.full_address || ''} `
-            : ''
-        }`
+          animal.building_name ? ` / ${animal.building_name}` : ""
+        }${
+          animal.room ? ` / ${animal.room_name}` : ""
+        }`,
       })
     }
 

--- a/frontend/src/dispatch/DispatchSearch.js
+++ b/frontend/src/dispatch/DispatchSearch.js
@@ -4,7 +4,7 @@ import { Button, ButtonGroup, Card, CardGroup, Form, FormControl, InputGroup, Ov
 import { Link, useQueryParams } from "raviger";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faCircle, faExclamationCircle, faQuestionCircle, faUserAlt, faUserAltSlash, faUsers
+  faCircle, faExclamationCircle, faQuestionCircle, faUserAlt, faUserAltSlash, faUsers, faPrint
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faDotCircle
@@ -12,7 +12,7 @@ import {
 import { faHomeAlt } from '@fortawesome/pro-solid-svg-icons';
 import L from "leaflet";
 import { Marker, Tooltip as MapTooltip } from "react-leaflet";
-import { useMark } from '../hooks';
+import { useMark, useSubmitting } from '../hooks';
 import Map, { prettyText, reportedMarkerIcon, SIPMarkerIcon, UTLMarkerIcon } from "../components/Map";
 import Moment from "react-moment";
 import moment from 'moment';
@@ -21,6 +21,8 @@ import Scrollbar from '../components/Scrollbars';
 import { ITEMS_PER_PAGE } from '../constants';
 import { DateRangePicker } from '../components/Form';
 import { SystemErrorContext } from '../components/SystemError';
+import ButtonSpinner from '../components/ButtonSpinner';
+import { printAllDispatchResolutions } from './Utils';
 
 function DispatchAssignmentSearch({ incident }) {
 
@@ -45,6 +47,12 @@ function DispatchAssignmentSearch({ incident }) {
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(moment().format('YYYY-MM-DD'));
   const { markInstances } = useMark();
+  const {
+    isSubmitting,
+    handleSubmitting,
+    submittingComplete,
+    submittingLabel
+  } = useSubmitting();
 
   // Update searchTerm when field input changes.
   const handleChange = event => {
@@ -56,6 +64,14 @@ function DispatchAssignmentSearch({ incident }) {
     event.preventDefault();
     setSearchTerm(tempSearchTerm.current.value);
     setPage(1);
+  }
+
+  const handlePrintAllClick = (e) => {
+    e.preventDefault();
+
+    handleSubmitting()
+      .then(() => printAllDispatchResolutions(evacAssignments))
+      .then(submittingComplete);
   }
 
   // Parses the Date Range object
@@ -188,6 +204,16 @@ function DispatchAssignmentSearch({ incident }) {
               }
             }}
           />
+          <ButtonSpinner
+            variant="outline-light"
+            className="ml-1"
+            onClick={handlePrintAllClick}
+            isSubmitting={isSubmitting}
+            isSubmittingText={submittingLabel}
+          >
+            Print All ({`${evacAssignments.length}`})
+            <FontAwesomeIcon icon={faPrint} className="ml-2 text-light" inverse />
+          </ButtonSpinner>
         </InputGroup>
       </Form>
       {evacAssignments.map((evacuation_assignment, index) => (

--- a/frontend/src/dispatch/Utils.js
+++ b/frontend/src/dispatch/Utils.js
@@ -1,8 +1,11 @@
+import moment from 'moment';
 import ShelterlyPDF from '../utils/pdf';
 import { priorityChoices } from '../constants';
 import { statusChoices } from '../animals/constants';
 
-export const printDispatchResolutionForm = (data) => {
+const dateFormat = 'YYYYMMDDHHmm';
+
+const buildDispatchResolutionsDoc = (drs = []) => {
   const pdf = new ShelterlyPDF({}, {
     // adds page numbers to the footer
     addFooterHandler: ({
@@ -16,263 +19,287 @@ export const printDispatchResolutionForm = (data) => {
       });
     },
     pageTitle: 'Dispatch Assignment',
-    pageSubtitle: `Opened: ${new Date(data.start_time).toLocaleDateString()}`
+    pageSubtitle: drs.length
+      ? `Opened: ${new Date(drs[0].start_time).toLocaleDateString()}`
+      : ''
   });
 
-  pdf.fileName = `DAR-${data.id.toString().padStart(3, 0)}`;
-
-  // draw team section
-  pdf.drawSectionHeader({ text: data.team_object.name, hRule: false });
-  pdf.drawTextList({
-    labels: data.team && data.team_object.team_member_objects.map(team_member => (
-      `${team_member.first_name} ${team_member.last_name} ${team_member.display_phone ? `${team_member.display_phone}` : ''}`
-    ))
-  });
-
-  pdf.drawPad();
-
-  // summary page
-  data.assigned_requests.forEach((assigned_request, index) => {
-    // service request priority
-    const srPriority = priorityChoices.find(({ value }) => value === (assigned_request.service_request_object.priority || 2))
-    // Summary page
-    pdf.drawSectionHeader({
-      text: `SR#${assigned_request.service_request_object.id} - ${srPriority.label} Priority`
-    });
-
-    pdf.drawPad(20);
-
-    // summary address
-    pdf.drawSectionHeader({ text: 'Service Request Address:', fontSize: 14 });
-
-    const [addressLine1, ...addressLine2] = assigned_request.service_request_object.full_address.split(',')
-
-    pdf.drawTextList({
-      labels: [
-        addressLine1,
-        addressLine2.join(',')?.trim?.()
-      ],
-      bottomPadding: 12
-    })
-
-    // lat/lng
-    pdf.drawWrappedText({
-      text: `Latitude: ${assigned_request.service_request_object.latitude},  Longitude: ${assigned_request.service_request_object.longitude}`
-    });
-
-    // Animal count
-    pdf.drawSectionHeader({ text: 'Animals', fontSize: 14 });
-
-    const animalCounts = [];
-    assigned_request.service_request_object.animals
-      .filter(animal => Object.keys(assigned_request.animals).includes(String(animal.id)))
-      .forEach((animal, index) => {
-        const countIndex = animalCounts.findIndex(([species]) => animal.species === species);
-        if (countIndex > -1) {
-          const [currentSpecies, oldCount] = animalCounts[countIndex];
-          animalCounts[countIndex] = [currentSpecies, oldCount + 1];
-        } else {
-          animalCounts.push([animal.species, 1]);
-        }
+  drs.forEach((data, i) => {
+    if (i > 0) {
+      pdf.drawPageBreak();
+      pdf.drawPageHeader({
+        subtitle: `Opened: ${new Date(data.start_time).toLocaleDateString()}`
       });
+    }
 
+    // draw team section
+    pdf.drawSectionHeader({ text: data.team_object.name, hRule: false });
     pdf.drawTextList({
-      labels: animalCounts.map(([species, count]) => (
-        // capitalize the species
-        `${species.replace(/(^.)/, m => m.toUpperCase())}: ${count}`
+      labels: data.team && data.team_object.team_member_objects.map(team_member => (
+        `${team_member.first_name} ${team_member.last_name} ${team_member.display_phone ? `${team_member.display_phone}` : ''}`
       ))
     });
 
-    pdf.drawPad(30);
-  });
+    pdf.drawPad();
 
-  // end of summary page break
-  pdf.drawPageBreak();
+    // summary page
+    data.assigned_requests.forEach((assigned_request, index) => {
+      // service request priority
+      const srPriority = priorityChoices.find(({ value }) => value === (assigned_request.service_request_object.priority || 2))
+      // Summary page
+      pdf.drawSectionHeader({
+        text: `SR#${assigned_request.service_request_object.id} - ${srPriority.label} Priority`
+      });
 
-  // loop through SR's and page break between each one
-  data.assigned_requests.forEach((assigned_request, index) => {
-    if (index > 0) {
-      pdf.drawPageBreak();
-    }
+      pdf.drawPad(20);
 
-    // SR Header
-    pdf.drawSectionHeader({
-      text: `SR#${assigned_request.service_request_object.id} - ${assigned_request.service_request_object.full_address}`,
-      hRule: false
-    });
-    pdf.drawPad(20);
-    pdf.drawWrappedText({
-      text: `Latitude: ${assigned_request.service_request_object.latitude},  Longitude: ${assigned_request.service_request_object.longitude}`
-    });
-    pdf.drawPad(-10);
-    pdf.drawHRule();
-    pdf.drawPad(-10);
-    pdf.drawCheckboxList({
-      labels: ['Completed', 'Not Completed Yet', 'Unable to Complete'],
-      listStyle: 'inline',
-    });
+      // summary address
+      pdf.drawSectionHeader({ text: 'Service Request Address:', fontSize: 14 });
 
-    // owners
-    if (assigned_request.service_request_object.owners.length) {
-      assigned_request.service_request_object.owner_objects.forEach((owner) => (
-        pdf.drawWrappedText({
-          text: `Owner: ${owner.first_name} ${owner.last_name} ${owner.display_phone}`
-        })
-      ));
-    }
+      const [addressLine1, ...addressLine2] = assigned_request.service_request_object.full_address.split(',')
 
-    // reporter
-    if (assigned_request.service_request_object.reporter_object) {
-      pdf.drawWrappedText({
-        text: `Reporter: ${assigned_request.service_request_object.reporter_object.first_name} ${assigned_request.service_request_object.reporter_object.last_name} ${assigned_request.service_request_object.reporter_object.agency ? '(' + assigned_request.service_request_object.reporter_object.agency + ')' : 'No'} ${assigned_request.service_request_object.reporter_object.display_phone}`
-      })
-    }
-
-    // additional info
-    pdf.drawWrappedText({
-      text: `Additional Information: ${assigned_request.service_request_object.directions || 'N/A'}`
-    });
-
-    // accessible
-    pdf.drawWrappedText({
-      text: `Accessible: ${assigned_request.service_request_object.accessible ? 'Yes' : 'No'}`
-    });
-
-    // turn around
-    pdf.drawWrappedText({
-      text: `Turn Around: ${assigned_request.service_request_object.turn_around ? 'Yes' : 'No'}`
-    });
-
-    // animals
-    pdf.drawSectionHeader({
-      text: 'Animals'
-    });
-
-    const dispatchStatusHeaders = [{
-      value: '', label: 'ID - Species\nName'
-    }].concat(statusChoices.filter((choice) => choice.value !== 'REPORTED'));
-
-    function drawAnimalHeader() {
       pdf.drawTextList({
-        labels: dispatchStatusHeaders.map((choice) => {
-          if (choice.label.indexOf('SIP') > -1) {
-            return 'SIP';
+        labels: [
+          addressLine1,
+          addressLine2.join(',')?.trim?.()
+        ],
+        bottomPadding: 12
+      })
+
+      // lat/lng
+      pdf.drawWrappedText({
+        text: `Latitude: ${assigned_request.service_request_object.latitude},  Longitude: ${assigned_request.service_request_object.longitude}`
+      });
+
+      // Animal count
+      pdf.drawSectionHeader({ text: 'Animals', fontSize: 14 });
+
+      const animalCounts = [];
+      assigned_request.service_request_object.animals
+        .filter(animal => Object.keys(assigned_request.animals).includes(String(animal.id)))
+        .forEach((animal, index) => {
+          const countIndex = animalCounts.findIndex(([species]) => animal.species === species);
+          if (countIndex > -1) {
+            const [currentSpecies, oldCount] = animalCounts[countIndex];
+            animalCounts[countIndex] = [currentSpecies, oldCount + 1];
+          } else {
+            animalCounts.push([animal.species, 1]);
           }
-          if (choice.label.indexOf('UTL') > -1) {
-            return 'UTL';
+        });
+
+      pdf.drawTextList({
+        labels: animalCounts.map(([species, count]) => (
+          // capitalize the species
+          `${species.replace(/(^.)/, m => m.toUpperCase())}: ${count}`
+        ))
+      });
+
+      pdf.drawPad(30);
+    });
+
+    // end of summary page break
+    pdf.drawPageBreak();
+
+    // loop through SR's and page break between each one
+    data.assigned_requests.forEach((assigned_request, index) => {
+      if (index > 0) {
+        pdf.drawPageBreak();
+      }
+
+      // SR Header
+      pdf.drawSectionHeader({
+        text: `SR#${assigned_request.service_request_object.id} - ${assigned_request.service_request_object.full_address}`,
+        hRule: false
+      });
+      pdf.drawPad(20);
+      pdf.drawWrappedText({
+        text: `Latitude: ${assigned_request.service_request_object.latitude},  Longitude: ${assigned_request.service_request_object.longitude}`
+      });
+      pdf.drawPad(-10);
+      pdf.drawHRule();
+      pdf.drawPad(-10);
+      pdf.drawCheckboxList({
+        labels: ['Completed', 'Not Completed Yet', 'Unable to Complete'],
+        listStyle: 'inline',
+      });
+
+      // owners
+      if (assigned_request.service_request_object.owners.length) {
+        assigned_request.service_request_object.owner_objects.forEach((owner) => (
+          pdf.drawWrappedText({
+            text: `Owner: ${owner.first_name} ${owner.last_name} ${owner.display_phone}`
+          })
+        ));
+      }
+
+      // reporter
+      if (assigned_request.service_request_object.reporter_object) {
+        pdf.drawWrappedText({
+          text: `Reporter: ${assigned_request.service_request_object.reporter_object.first_name} ${assigned_request.service_request_object.reporter_object.last_name} ${assigned_request.service_request_object.reporter_object.agency ? '(' + assigned_request.service_request_object.reporter_object.agency + ')' : 'No'} ${assigned_request.service_request_object.reporter_object.display_phone}`
+        })
+      }
+
+      // additional info
+      pdf.drawWrappedText({
+        text: `Additional Information: ${assigned_request.service_request_object.directions || 'N/A'}`
+      });
+
+      // accessible
+      pdf.drawWrappedText({
+        text: `Accessible: ${assigned_request.service_request_object.accessible ? 'Yes' : 'No'}`
+      });
+
+      // turn around
+      pdf.drawWrappedText({
+        text: `Turn Around: ${assigned_request.service_request_object.turn_around ? 'Yes' : 'No'}`
+      });
+
+      // animals
+      pdf.drawSectionHeader({
+        text: 'Animals'
+      });
+
+      const dispatchStatusHeaders = [{
+        value: '', label: 'ID - Species\nName'
+      }].concat(statusChoices.filter((choice) => choice.value !== 'REPORTED'));
+
+      function drawAnimalHeader() {
+        pdf.drawTextList({
+          labels: dispatchStatusHeaders.map((choice) => {
+            if (choice.label.indexOf('SIP') > -1) {
+              return 'SIP';
+            }
+            if (choice.label.indexOf('UTL') > -1) {
+              return 'UTL';
+            }
+            if (choice.label.indexOf('No Further Action (NFA)') > -1) {
+              return 'No Further Action';
+            }
+
+            return choice.label;
+          }),
+          listStyle: 'inline',
+          bottomPadding: 5
+        });
+
+        pdf.drawHRule();
+      }
+
+      // draw the animals header before the animals table
+      pdf.setDocumentFontSize({ size: 10 });
+      drawAnimalHeader();
+      
+
+      // keep the last y position after a row was drawn
+      let lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+      assigned_request.service_request_object.animals.filter(animal => Object.keys(assigned_request.animals).includes(String(animal.id))).forEach((animal) => {
+        // grab the last y position before we draw a row
+        const lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+
+        const animalRow = [{
+          label: `A#${animal.id} - ${animal.species[0].toUpperCase()}${animal.species.slice(1)}\n${animal.name || 'Unknown'}\n${animal.status}`,
+          marginTop: -10
+        }].concat(Array(5).fill({
+          type: 'checkbox',
+          label: '',
+          size: 20
+        }));
+
+        pdf.drawList({
+          listItems: animalRow,
+          listStyle: 'inline',
+          bottomPadding: 0
+        });
+
+        pdf.drawWrappedText({
+          text: `Primary Color: ${animal.pcolor || 'N/A'}, Secondary Color: ${animal.scolor || 'N/A'}`,
+          linePadding: 10
+        });
+        pdf.drawWrappedText({
+          text: `Description: ${animal.color_notes || 'N/A'}`,
+          bottomPadding: 0
+        });
+        pdf.drawWrappedText({
+          text: `Behavior: ${animal.behavior_notes || 'N/A'}`,
+          bottomPadding: 0,
+        });
+        pdf.drawWrappedText({
+          text: `Medical: ${animal.medical_notes || 'N/A'}`
+        });
+
+        lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+
+        // If after draw y position is less than before draw, that means there was a page break.
+        // Draw the animal header again.
+        if (lastYPosAfterDraw < lastYPosBeforeDraw) {
+          drawAnimalHeader();
+        }
+      });
+
+      pdf.setDocumentFontSize();
+
+      // priorities
+      pdf.drawSectionHeader({ text: 'Priority', hRule: true });
+      pdf.setDocumentFontSize({ size: 10 });
+      const currentPriority = assigned_request.service_request_object.priority || 2
+      pdf.drawCheckboxList({
+        labels: priorityChoices.map(({ value, label}) => {
+          if (value === currentPriority) {
+            return `${label} (Current)`
           }
-          if (choice.label.indexOf('No Further Action (NFA)') > -1) {
-            return 'No Further Action';
-          }
-  
-          return choice.label;
+          return label
         }),
         listStyle: 'inline',
+      });
+      pdf.setDocumentFontSize();
+
+      // date completed, followup, etc..
+      pdf.drawTextList({
+        labels: [
+          'Date Completed:  ________/________/________________'
+        ],
         bottomPadding: 5
       });
-  
-      pdf.drawHRule();
-    }
+      pdf.drawTextList({
+        labels: [
+          'Followup Date:  ________/________/________________'
+        ],
+        bottomPadding: 16
+      })
+      pdf.drawTextArea({ label: 'Visit Notes:', rows: 4 });
+      pdf.drawCheckBoxLine({ label: 'Forced Entry' });
 
-    // draw the animals header before the animals table
-    pdf.setDocumentFontSize({ size: 10 });
-    drawAnimalHeader();
-    
+      // owners contacted
+      if (assigned_request.service_request_object.owners.length) {
+        pdf.drawTextList({
+          labels: ['Owner Contacted:']
+        });
 
-    // keep the last y position after a row was drawn
-    let lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
-    assigned_request.service_request_object.animals.filter(animal => Object.keys(assigned_request.animals).includes(String(animal.id))).forEach((animal) => {
-      // grab the last y position before we draw a row
-      const lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
-
-      const animalRow = [{
-        label: `A#${animal.id} - ${animal.species[0].toUpperCase()}${animal.species.slice(1)}\n${animal.name || 'Unknown'}\n${animal.status}`,
-        marginTop: -10
-      }].concat(Array(5).fill({
-        type: 'checkbox',
-        label: '',
-        size: 20
-      }));
-
-      pdf.drawList({
-        listItems: animalRow,
-        listStyle: 'inline',
-        bottomPadding: 0
-      });
-
-      pdf.drawWrappedText({
-        text: `Primary Color: ${animal.pcolor || 'N/A'}, Secondary Color: ${animal.scolor || 'N/A'}`,
-        linePadding: 10
-      });
-      pdf.drawWrappedText({
-        text: `Description: ${animal.color_notes || 'N/A'}`,
-        bottomPadding: 5
-      });
-      pdf.drawWrappedText({
-        text: `Behavior: ${animal.behavior_notes || 'N/A'}`,
-        bottomPadding: 5,
-        linePadding: -10
-      });
-      pdf.drawWrappedText({
-        text: `Medical: ${animal.medical_notes || 'N/A'}`,
-        linePadding: -10
-      });
-
-      lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
-
-      // If after draw y position is less than before draw, that means there was a page break.
-      // Draw the animal header again.
-      if (lastYPosAfterDraw < lastYPosBeforeDraw) {
-        drawAnimalHeader();
+        assigned_request.service_request_object.owner_objects.forEach((owner) => {
+          pdf.drawCheckBoxLine({ label: `Owner: ${owner.first_name} ${owner.last_name} ${owner.display_phone}` });
+          pdf.drawTextWithLine({ label: 'Owner Contact Time:', xOffset: 150 });
+          pdf.drawTextArea({ label: 'Owner Contact Notes:' });
+        });
       }
     });
-
-    pdf.setDocumentFontSize();
-
-    // priorities
-    pdf.drawSectionHeader({ text: 'Priority', hRule: true });
-    pdf.setDocumentFontSize({ size: 10 });
-    const currentPriority = assigned_request.service_request_object.priority || 2
-    pdf.drawCheckboxList({
-      labels: priorityChoices.map(({ value, label}) => {
-        if (value === currentPriority) {
-          return `${label} (Current)`
-        }
-        return label
-      }),
-      listStyle: 'inline',
-    });
-    pdf.setDocumentFontSize();
-
-    // date completed, followup, etc..
-    pdf.drawTextList({
-      labels: [
-        'Date Completed:  ________/________/________________'
-      ],
-      bottomPadding: 5
-    });
-    pdf.drawTextList({
-      labels: [
-        'Followup Date:  ________/________/________________'
-      ],
-      bottomPadding: 16
-    })
-    pdf.drawTextArea({ label: 'Visit Notes:', rows: 4 });
-    pdf.drawCheckBoxLine({ label: 'Forced Entry' });
-
-    // owners contacted
-    if (assigned_request.service_request_object.owners.length) {
-      pdf.drawTextList({
-        labels: ['Owner Contacted:']
-      });
-
-      assigned_request.service_request_object.owner_objects.forEach((owner) => {
-        pdf.drawCheckBoxLine({ label: `Owner: ${owner.first_name} ${owner.last_name} ${owner.display_phone}` });
-        pdf.drawTextWithLine({ label: 'Owner Contact Time:', xOffset: 150 });
-        pdf.drawTextArea({ label: 'Owner Contact Notes:' });
-      });
-    }
   });
 
-  pdf.saveFile();
+  return pdf;
 }
+
+function printDispatchResolutionForm(dr = {}) {
+  const pdf = buildDispatchResolutionsDoc([dr]);
+  pdf.fileName = `DAR-${dr.id.toString().padStart(3, 0)}`;
+  return pdf.saveFile();
+}
+
+function printAllDispatchResolutions(drs = []) {
+  const pdf = buildDispatchResolutionsDoc(drs);
+  pdf.fileName = `DARs-${moment().format(dateFormat)}`;
+  return pdf.saveFile();
+}
+
+export {
+  printDispatchResolutionForm,
+  printAllDispatchResolutions
+};

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { default as useMark } from './useMark';
+export { default as useSubmitting } from './useSubmitting';

--- a/frontend/src/hooks/useSubmitting.js
+++ b/frontend/src/hooks/useSubmitting.js
@@ -1,0 +1,32 @@
+import { useState } from "react";
+
+/**
+ * a simple hook for using a submitting state
+ * @param {object} [param0]
+ * @param {string} [uiLabel='Printifying...   '] optionally use this as the submitting label message in the UI
+ * @returns 
+ */
+function useSubmitting({
+  uiLabel = 'Printifying...   '
+} = {}) {
+  const submittingLabel = uiLabel;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function submittingComplete() {
+    setIsSubmitting(false);
+  }
+
+  async function handleSubmitting() {
+    setIsSubmitting(true);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+
+  return {
+    isSubmitting,
+    submittingComplete,
+    handleSubmitting,
+    submittingLabel
+  };
+}
+
+export default useSubmitting;

--- a/frontend/src/hotline/ServiceRequestSearch.js
+++ b/frontend/src/hotline/ServiceRequestSearch.js
@@ -4,19 +4,21 @@ import { Link, useQueryParams } from 'raviger';
 import { Button, ButtonGroup, Card, CardGroup, Form, FormControl, InputGroup, ListGroup, OverlayTrigger, Pagination, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faBan, faCar, faChevronDown, faChevronUp, faEquals, faClipboardList, faEnvelope, faKey, faTrailer, faUsers
+  faBan, faCar, faChevronDown, faChevronUp, faEquals, faClipboardList, faEnvelope, faKey, faTrailer, faUsers, faPrint
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faDotCircle
 } from '@fortawesome/free-regular-svg-icons';
 import { faChevronDoubleDown, faChevronDoubleUp, faCommentSmile, faPhoneRotary } from '@fortawesome/pro-solid-svg-icons';
 import Moment from 'react-moment';
-import { useMark } from '../hooks';
+import { useMark, useSubmitting } from '../hooks';
 import Header from '../components/Header';
 import Scrollbar from '../components/Scrollbars';
 import { speciesChoices } from '../animals/constants';
 import { ITEMS_PER_PAGE } from '../constants';
 import { SystemErrorContext } from '../components/SystemError';
+import ButtonSpinner from '../components/ButtonSpinner';
+import { printAllServiceRequests } from './Utils';
 
 function ServiceRequestSearch({ incident }) {
 
@@ -39,6 +41,12 @@ function ServiceRequestSearch({ incident }) {
   const [page, setPage] = useState(1);
   const [numPages, setNumPages] = useState(1);
   const { markInstances } = useMark();
+  const {
+    isSubmitting,
+    handleSubmitting,
+    submittingComplete,
+    submittingLabel
+  } = useSubmitting();
 
   // Update searchTerm when field input changes.
   const handleChange = event => {
@@ -50,6 +58,14 @@ function ServiceRequestSearch({ incident }) {
     event.preventDefault();
     setSearchTerm(tempSearchTerm.current.value);
     setPage(1);
+  }
+
+  const handlePrintAllClick = (e) => {
+    e.preventDefault();
+
+    handleSubmitting()
+      .then(() => printAllServiceRequests(data.service_requests))
+      .then(submittingComplete);
   }
 
   function setFocus(pageNum) {
@@ -130,6 +146,16 @@ function ServiceRequestSearch({ incident }) {
             <Button variant={statusOptions === "closed" ? "primary" : "secondary"} onClick={statusOptions !== "closed" ? () => {setPage(1);setStatusOptions("closed")} : () => {setPage(1);setStatusOptions("")}}>Closed</Button>
             <Button variant={statusOptions === "canceled" ? "primary" : "secondary"} onClick={statusOptions !== "canceled" ? () => {setPage(1);setStatusOptions("canceled")} : () => {setPage(1);setStatusOptions("")}}>Canceled</Button>
           </ButtonGroup>
+          <ButtonSpinner
+            variant="outline-light"
+            className="ml-1"
+            onClick={handlePrintAllClick}
+            isSubmitting={isSubmitting}
+            isSubmittingText={submittingLabel}
+          >
+            Print All ({`${data.service_requests.length}`})
+            <FontAwesomeIcon icon={faPrint} className="ml-2 text-light" inverse />
+          </ButtonSpinner>
         </InputGroup>
       </Form>
       {data.service_requests.map((service_request, index) => (

--- a/frontend/src/people/PersonSearch.js
+++ b/frontend/src/people/PersonSearch.js
@@ -4,17 +4,20 @@ import { Link, useQueryParams } from 'raviger';
 import { Button, ButtonGroup, Card, CardGroup, Form, FormControl, InputGroup, ListGroup, OverlayTrigger, Pagination, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faClipboardList
+  faClipboardList,
+  faPrint
 } from '@fortawesome/free-solid-svg-icons';
 import {
   faDotCircle
 } from '@fortawesome/free-regular-svg-icons';
-import { useMark } from '../hooks';
+import { useMark, useSubmitting } from '../hooks';
 import Header from '../components/Header';
 import Scrollbar from '../components/Scrollbars';
+import ButtonSpinner from '../components/ButtonSpinner';
 import { speciesChoices } from '../animals/constants';
 import { ITEMS_PER_PAGE } from '../constants';
 import { SystemErrorContext } from '../components/SystemError';
+import { printAllOwnersDetails } from './Utils';
 
 function PersonSearch({ incident }) {
 
@@ -35,6 +38,12 @@ function PersonSearch({ incident }) {
 	const [page, setPage] = useState(1);
   const [numPages, setNumPages] = useState(1);
 	const { markInstances } = useMark();
+  const {
+    isSubmitting,
+    handleSubmitting,
+    submittingComplete,
+    submittingLabel
+  } = useSubmitting();
 
   // Update searchTerm when field input changes.
   const handleChange = event => {
@@ -46,6 +55,14 @@ function PersonSearch({ incident }) {
     event.preventDefault();
     setSearchTerm(tempSearchTerm.current.value);
 		setPage(1);
+  }
+
+  function handlePrintAllClick(e) {
+    e.preventDefault();
+
+    handleSubmitting()
+      .then(() => printAllOwnersDetails(data.owners))
+      .then(submittingComplete);
   }
 
 	function setFocus(pageNum) {
@@ -129,6 +146,15 @@ function PersonSearch({ incident }) {
           <Button variant={statusOptions === "owners" ? "primary" : "secondary"} onClick={statusOptions !== "owners" ? () => {setPage(1);setStatusOptions("owners")} : () => {setPage(1);setStatusOptions("")}}>Owners</Button>
           <Button variant={statusOptions === "reporters" ? "primary" : "secondary"} onClick={statusOptions !== "reporters" ? () => {setPage(1);setStatusOptions("reporters")} : () => {setPage(1);setStatusOptions("")}}>Reporters</Button>
         </ButtonGroup>
+        <ButtonSpinner
+          variant="outline-light ml-2"
+          onClick={handlePrintAllClick}
+          isSubmitting={isSubmitting}
+          isSubmittingText={submittingLabel}
+        >
+          Print All ({`${data.owners.length}`})
+          <FontAwesomeIcon icon={faPrint} className="ml-2 text-light" inverse />
+        </ButtonSpinner>
       </InputGroup>
     </Form>
     {data.owners.map((owner, index) => (

--- a/frontend/src/people/PersonSearch.js
+++ b/frontend/src/people/PersonSearch.js
@@ -202,7 +202,7 @@ function PersonSearch({ incident }) {
                     <ListGroup.Item><b>Address: </b>{owner.full_address}</ListGroup.Item>
                   : ""}
                   {owner.requests && owner.requests.map(request => (
-                    <ListGroup.Item><b>Service Request: </b><Link href={"/" + incident + "/hotline/servicerequest/" + request.id} className="text-link" style={{textDecoration:"none", color:"white"}}>{request.full_address}</Link></ListGroup.Item>
+                    <ListGroup.Item key={request.id}><b>Service Request: </b><Link href={"/" + incident + "/hotline/servicerequest/" + request.id} className="text-link" style={{textDecoration:"none", color:"white"}}>{request.full_address}</Link></ListGroup.Item>
                   ))}
                 </ListGroup>
               </Scrollbar>
@@ -212,7 +212,7 @@ function PersonSearch({ incident }) {
           <Card style={{marginBottom:"6px"}}>
             <Card.Body style={{width:"525px"}}>
               <Card.Title style={{marginTop:"-10px"}}>
-                <Scrollbar horizontal autoHide style={{height:"32px", width:"485px"}} renderView={props => <div {...props} style={{...props.style, marginBottom:"-18px", marginRight:"0px", overflowX:"auto", overflowY: "hidden"}}/>} renderThumbVertical={props => <div {...props} style={{...props.style, display: 'none'}} />}>
+                <Scrollbar horizontal="true" autoHide style={{height:"32px", width:"485px"}} renderView={props => <div {...props} style={{...props.style, marginBottom:"-18px", marginRight:"0px", overflowX:"auto", overflowY: "hidden"}}/>} renderThumbVertical={props => <div {...props} style={{...props.style, display: 'none'}} />}>
                   <ListGroup horizontal>
                   {searchState[owner.id].species.map(species => (
                     <ListGroup.Item key={species} active={searchState[owner.id].selectedSpecies === species ? true : false} style={{textTransform:"capitalize", cursor:'pointer', paddingTop:"4px", paddingBottom:"4px"}} onClick={() => setSearchState(prevState => ({ ...prevState, [owner.id]:{...prevState[owner.id], selectedSpecies:species} }))}>{species}{species !== "other" ? "s" : ""}</ListGroup.Item>

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -8,7 +8,18 @@ const dateFormat = 'YYYYMMDDHHmm';
 const buildOwnersDoc = (owners) => {
   const pdf = new ShelterlyPDF({}, {
     pageTitle: 'Owner Summary',
-    pageSubtitle: `Date: ${new Date().toLocaleDateString()}`
+    pageSubtitle: `Date: ${new Date().toLocaleDateString()}`,
+    // adds page numbers to the footer
+    addFooterHandler: ({
+      pageNumber,
+      pageCount,
+      pdf
+    }) => {
+      const { width: pageWidth, height: pageHeight } = pdf.internal.pageSize;
+      pdf.text('Page ' + String(pageNumber) + ' of ' + String(pageCount), pageWidth / 2, pageHeight - 15, {
+        align: 'center'
+      });
+    }
   });
 
   owners.forEach((owner, i) => {

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -5,101 +5,135 @@ import { buildAnimalCareScheduleDoc } from '../animals/Utils';
 
 const dateFormat = 'YYYYMMDDHHmm';
 
-export const printOwnerDetails = (owner) => {
+const buildOwnersDoc = (owners) => {
   const pdf = new ShelterlyPDF({}, {
     pageTitle: 'Owner Summary',
     pageSubtitle: `Date: ${new Date().toLocaleDateString()}`
   });
 
-  pdf.fileName = `Owner-Summary-${owner.id.toString().padStart(3, 0)}`;
-
-  // draw owner section
-  pdf.drawSectionHeader({ text: 'Owner Details', hRule: true });
-  
-  const ownerInfoList = [`Name: ${owner.first_name} ${owner.last_name}`];
-  if (owner.agency) ownerInfoList.push(`Agency: ${owner.agency}`);
-  if (owner.phone) ownerInfoList.push(`Telephone: ${owner.display_phone} ${owner.display_alt_phone ? `  Alt: ${owner.display_alt_phone}` : ''}`);
-  if (owner.email) ownerInfoList.push(`Email: ${owner.email}`);
-  if (owner.request) ownerInfoList.push(`Service Request: ${owner.request.full_address}`);
-  else {
-    if (owner.address) ownerInfoList.push(`Address: ${owner.full_address}`);
-    else ownerInfoList.push('Address: No Address Listed');
-  }
-
-  pdf.drawTextList({
-    labels: ownerInfoList,
-    bottomPadding: 15
-  });
-
-  if (owner.comments) {
-    pdf.drawWrappedText({
-      text: `Comments: ${owner.comments}`
-    })
-  }
-
-  pdf.drawPad();
-
-  function drawAnimalHeader() {
-    pdf.drawSectionHeader({ text: 'Animals', hRule: true });
-  }
-
-  drawAnimalHeader();
-
-  // keep the last y position after a row was drawn
-  let lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
-  owner.animals.forEach((animal) => {
-    // grab the last y position before we draw a row
-    const lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
-
-    const animalInfoList = [
-      `ID: A#${animal.id}`,
-      `Status: ${capitalize(animal.status.toLowerCase(), { proper: true })}`,
-      `Name: ${animal.name || 'Unknown'}`,
-      `Species: ${capitalize(animal.species)}`,
-      `Sex: ${capitalize(animal.sex|| 'Unknown')}`,
-      `Age: ${capitalize(animal.age || 'Unknown')}`,
-      `Size: ${capitalize(animal.size || 'Unknown')}`,
-      `Primary Color: ${capitalize(animal.pcolor || 'N/A')}, Secondary Color: ${capitalize(animal.scolor || 'N/A')}`
-    ];
-
-    pdf.drawTextList({
-      labels: animalInfoList,
-      listStyle: 'grid',
-      bottomPadding: 0
-    });
-
-    pdf.drawPad();
-
-    if (animal.color_notes) {
-      pdf.drawWrappedText({
-        text: `Breed / Description: ${animal.color_notes}`,
-        linePadding: -5
-      });
+  owners.forEach((owner, i) => {
+    if (i > 0) {
+      pdf.drawPageBreak();
+      pdf.drawPageHeader();
     }
 
-    if (animal.shelter) {
+    // draw owner section
+    pdf.drawSectionHeader({ text: 'Owner Details', hRule: true });
+    
+    const ownerInfoList = [`Name: ${owner.first_name} ${owner.last_name}`];
+    if (owner.agency) ownerInfoList.push(`Agency: ${owner.agency}`);
+    if (owner.phone) ownerInfoList.push(`Telephone: ${owner.display_phone} ${owner.display_alt_phone ? `  Alt: ${owner.display_alt_phone}` : ''}`);
+    if (owner.email) ownerInfoList.push(`Email: ${owner.email}`);
+    if (owner.request) ownerInfoList.push(`Service Request: ${owner.request.full_address}`);
+    else {
+      if (owner.address) ownerInfoList.push(`Address: ${owner.full_address}`);
+      else ownerInfoList.push('Address: No Address Listed');
+    }
+
+    pdf.drawTextList({
+      labels: ownerInfoList,
+      bottomPadding: 15
+    });
+
+    if (owner.comments) {
       pdf.drawWrappedText({
-        text: `Shelter Address: ${animal.shelter_object?.full_address || 'Unknown'}`,
-        linePadding: 5
+        text: `Comments: ${owner.comments}`
       })
     }
 
-    pdf.drawPad(5);
-    pdf.drawHRule();
-    lastYPosAfterDraw = pdf.getLastYPositionWithBuffer();
+    pdf.drawPad();
 
-    // If after draw y position is less than before draw, that means there was a page break.
-    // Draw the animal header again.
-    if (lastYPosAfterDraw < lastYPosBeforeDraw) {
-      drawAnimalHeader();
+    function drawAnimalHeader() {
+      pdf.drawSectionHeader({ text: 'Animals', hRule: true });
     }
+
+    drawAnimalHeader();
+
+    // keep the last y position after a row was drawn
+    let lastYPosAfterDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+    owner.animals.forEach((animal, animalIndex) => {
+      // grab the last y position before we draw a row
+      let lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+      
+      // look ahead to see if this animal will bleed to the next page
+      const estimatedAnimalHeight = 162 // this is a magic number, it should change if we add or remove properties to render for animals
+      if (pdf.remainderPageHeight <= estimatedAnimalHeight) {
+        pdf.drawPageBreak();
+        drawAnimalHeader();
+        lastYPosBeforeDraw = pdf.getLastYPositionWithBuffer({ buffer: 0 });
+      }
+
+      const animalInfoList = [
+        `ID: A#${animal.id}`,
+        `Status: ${capitalize(animal.status.toLowerCase(), { proper: true })}`,
+        `Name: ${animal.name || 'Unknown'}`,
+        `Species: ${capitalize(animal.species)}`,
+        `Sex: ${capitalize(animal.sex|| 'Unknown')}`,
+        `Age: ${capitalize(animal.age || 'Unknown')}`,
+        `Size: ${capitalize(animal.size || 'Unknown')}`,
+        `Primary Color: ${capitalize(animal.pcolor || 'N/A')}, Secondary Color: ${capitalize(animal.scolor || 'N/A')}`
+      ];
+
+      pdf.drawTextList({
+        labels: animalInfoList,
+        listStyle: 'grid',
+        bottomPadding: 0
+      });
+
+      pdf.drawPad();
+
+      if (animal.color_notes) {
+        pdf.drawWrappedText({
+          text: `Breed / Description: ${animal.color_notes}`,
+          linePadding: -5
+        });
+      }
+
+      if (animal.shelter) {
+        pdf.drawWrappedText({
+          text: `Shelter Address: ${animal.shelter_object?.full_address || 'Unknown'}`,
+          linePadding: 5
+        })
+      }
+
+      pdf.drawPad(5);
+      pdf.drawHRule();
+      lastYPosAfterDraw = pdf.getLastYPositionWithBuffer();
+
+      // If after draw y position is less than before draw, that means there was a page break.
+      // Draw the animal header again.
+      if (
+          lastYPosAfterDraw < lastYPosBeforeDraw &&
+          animalIndex < owner.animals.length - 1
+        ) {
+        drawAnimalHeader();
+      }
+    });
   });
 
-  pdf.saveFile();
+  return pdf;
 };
 
-export const printOwnerAnimalCareSchedules  = async (animals = [], ownerId = 0) => {
+function printOwnerDetails(owner = {}) {
+  const pdf = buildOwnersDoc([owner]);
+  pdf.fileName = `Owner-Summary-${owner.id.toString().padStart(3, 0)}`;
+  return pdf.saveFile();
+}
+
+async function printAllOwnersDetails(owners = []) {
+  const pdf = buildOwnersDoc(owners);
+  pdf.fileName = `Owner-Summaries-${moment().format(dateFormat)}`;
+  return pdf.saveFile();
+}
+
+const printOwnerAnimalCareSchedules  = async (animals = [], ownerId = 0) => {
   const  pdf = await buildAnimalCareScheduleDoc(animals);
   pdf.fileName = `Shelterly-Owner-Animal-Care-Schedules-${ownerId.toString().padStart(4, 0)}-${moment().format(dateFormat)}`;
-  pdf.saveFile();
+  return pdf.saveFile();
 };
+
+export {
+  printOwnerDetails,
+  printAllOwnersDetails,
+  printOwnerAnimalCareSchedules
+}


### PR DESCRIPTION
This PR adresses 3 issues (#508, #513, #516), below are notes on each.

## Issue #508 - print all button on all search pages
As advertised, the "Print All" button exists on all the search pages now

## Issue #513 - pdf file sizes
This was a simple change available via the core pdf library we are using, and file sizes are <1mb instead of 10mb, thats awesome! However, a noticeable lag now exists between user click and file download, and given the nature of the change, that is to be expected. I added a "spinner" to those buttons to help UX.

Note: I wanted to add the spinner to the original print icon buttons (on the details pages) but that change wasn't easy and started to blow up scope. A nice to have ticket should be filed.

## Issue #516 animal care schedule
This is all good, one thing though, I was not 100% sure how to show the shelter location, so if a shelter object exists, I display the location info, including address, building and room name if available, and on a new line below the main image part. Let me know if that's what was desired.

More notes:

ShelterlyPDF updates
 - smaller file size on save
 - customizable column sizes for animal care schedule
 - fixes paging in the middle of "components"
 - fast image compression (to aid file size)
 - returns Promise on saveFile

closes #508
closes #513
closes #516