### PR TITLE
Adds owner paging, and owner liability form to pdf

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -8,11 +8,13 @@ export const STATE_OPTIONS = [{ value: 'AL', label: "AL" }, { value: 'AK', label
   { value: 'OK', label: "OK" }, { value: 'OR', label: "OR" }, { value: 'PA', label: "PA" }, { value: 'RI', label: "RI" }, { value: 'SC', label: "SC" }, { value: 'SD', label: "SD" }, { value: 'TN', label: "TN" },
   { value: 'TX', label: "TX" }, { value: 'VA', label: "VA" }, { value: "VT", label: "VT" }, { value: 'WA', label: "WA" }, { value: 'WV', label: "WV" }, { value: 'WI', label: "WI" }, { value: 'WY', label: "WY" },]
 
-  export const priorityChoices = [
-    { value: 1, label: 'Highest' },
-    { value: 2, label: 'High' },
-    { value: 3, label: 'Medium' },
-    { value: 4, label: 'Low' },
-    { value: 5, label: 'Lowest' }
-  ];
-  
+export const priorityChoices = [
+  { value: 1, label: 'Highest' },
+  { value: 2, label: 'High' },
+  { value: 3, label: 'Medium' },
+  { value: 4, label: 'Low' },
+  { value: 5, label: 'Lowest' }
+];
+
+export const ORGANIZATION_NAME = 'Butte County Animal Control/NVADG';
+export const ORGANIZATION_SHORT_NAME = 'BC/NVADG';

--- a/frontend/src/dispatch/Utils.js
+++ b/frontend/src/dispatch/Utils.js
@@ -8,16 +8,7 @@ const dateFormat = 'YYYYMMDDHHmm';
 const buildDispatchResolutionsDoc = (drs = []) => {
   const pdf = new ShelterlyPDF({}, {
     // adds page numbers to the footer
-    addFooterHandler: ({
-      pageNumber,
-      pageCount,
-      pdf
-    }) => {
-      const { width: pageWidth, height: pageHeight } = pdf.internal.pageSize;
-      pdf.text('Page ' + String(pageNumber) + ' of ' + String(pageCount), pageWidth / 2, pageHeight - 15, {
-        align: 'center'
-      });
-    },
+    addFooterHandler: ShelterlyPDF.HandlerTypes.DEFAULT,
     pageTitle: `Dispatch Assignment ${drs.length ? `#${drs[0].id}` : ''}`,
     pageSubtitle: drs.length
       ? `Opened: ${new Date(drs[0].start_time).toLocaleDateString()}`

--- a/frontend/src/hotline/Utils.js
+++ b/frontend/src/hotline/Utils.js
@@ -9,16 +9,7 @@ const dateFormat = 'YYYYMMDDHHmm';
 function buildServiceRequestsDoc(srs = []) {
   const pdf = new ShelterlyPDF({}, {
     // adds page numbers to the footer
-    addFooterHandler: ({
-      pageNumber,
-      pageCount,
-      pdf
-    }) => {
-      const { width: pageWidth, height: pageHeight } = pdf.internal.pageSize;
-      pdf.text('Page ' + String(pageNumber) + ' of ' + String(pageCount), pageWidth / 2, pageHeight - 15, {
-        align: 'center'
-      });
-    },
+    addFooterHandler: ShelterlyPDF.HandlerTypes.DEFAULT,
     pageTitle: 'Service Request Summary',
     pageSubtitle: ' '
   });

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -124,7 +124,6 @@ const buildOwnersDoc = (owners) => {
     });
 
     const estimatedSectionHeight = 529;
-    console.log('🚀 ~ file: Utils.js:128 ~ owners.forEach ~ pdf.remainderPageHeight:', pdf.remainderPageHeight)
     if (pdf.remainderPageHeight <= estimatedSectionHeight) {
       pdf.drawPageBreak();
       ownerPageCount++;
@@ -146,7 +145,7 @@ const buildOwnersDoc = (owners) => {
 
     function drawAgreements(agreements) {
       agreements.forEach((agreement, i) => {
-        pdf.drawWrappedText({ text: `${i})    ${agreement}`, linePadding: -3, bottomPadding: 5 })
+        pdf.drawWrappedText({ text: `${i + 1})    ${agreement}`, linePadding: -3, bottomPadding: 5 })
       });
     }
 

--- a/frontend/src/people/Utils.js
+++ b/frontend/src/people/Utils.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import ShelterlyPDF from '../utils/pdf';
 import { capitalize } from '../utils/formatString';
 import { buildAnimalCareScheduleDoc } from '../animals/Utils';
+import { ORGANIZATION_NAME, ORGANIZATION_SHORT_NAME } from "../constants";
 
 const dateFormat = 'YYYYMMDDHHmm';
 
@@ -120,6 +121,86 @@ const buildOwnersDoc = (owners) => {
         ) {
         drawAnimalHeader();
       }
+    });
+
+    const estimatedSectionHeight = 529;
+    console.log('🚀 ~ file: Utils.js:128 ~ owners.forEach ~ pdf.remainderPageHeight:', pdf.remainderPageHeight)
+    if (pdf.remainderPageHeight <= estimatedSectionHeight) {
+      pdf.drawPageBreak();
+      ownerPageCount++;
+    }
+
+    // Draw liability form
+    pdf.drawSectionHeader({
+      text: "Liability Release",
+      hRule: false,
+      align: ShelterlyPDF.AlignTypes.CENTER,
+    });
+    pdf.drawPad(18);
+    let liabilityPreface = `Due to a declared emergency, I am requesting ${ORGANIZATION_NAME} to board my animal(s) `;
+    liabilityPreface += '(listed above) and agree to all of the following:';
+    pdf.setDocumentFontSize({ size: 8 });
+    pdf.drawWrappedText({ text: liabilityPreface, linePadding: -2 });
+    pdf.drawHRule({ buffer: 1});
+    pdf.setDocumentFontSize();
+
+    function drawAgreements(agreements) {
+      agreements.forEach((agreement, i) => {
+        pdf.drawWrappedText({ text: `${i})    ${agreement}`, linePadding: -3, bottomPadding: 5 })
+      });
+    }
+
+    const agreements = [
+      // 1)
+      'I understand that my animal(s) may be exposed to disease and other risks while being ' +
+      'housed at the shelter and other facilities and therefore I will not hold ' +
+      `${ORGANIZATION_NAME} responsible for the health or death of my animal(s).`,
+
+      // 2)
+      'I agree to attempt to find alternate housing for my animal(s) as soon as possible.',
+
+      // 3)
+      `I agree to contact the agency on a regular basis to keep ${ORGANIZATION_NAME} ` +
+      'updated on my whereabouts and possible alternate housing.',
+
+      // 4)
+      'I understand that this boarding agreement is temporary and I agree to make arrangements ' +
+      'for or claim my pet(s) at the close of the shelter.',
+
+      // 5)
+      'I understand that I will be subject to boarding fees at the close of the shelter.',
+
+      // 6)
+      'I understand that photographs of myself and my animal(s) may be taken.'
+    ];
+
+    drawAgreements(agreements);
+
+    const releaseLabels = [
+      "I Allow",
+      { label: "or", type: "text" },
+      "I Decline",
+      {
+        label:
+          "any photos that are taken to be released to the media or public view",
+        type: "text",
+      }
+    ].concat(Array(7).fill({
+      label: ' ',
+      type: 'text'
+    }));
+    pdf.drawCheckboxList({
+      labels: releaseLabels,
+      listStyle: 'inline',
+    });
+
+    // pdf.drawTextWithLine({ label: 'Owner\'s Signature', xOffset: 100 });
+
+    pdf.drawTextList({
+      labels: ['Owner\'s Signature: ', 'Date: ', `${ORGANIZATION_SHORT_NAME} Witness: `],
+      listStyle: 'grid',
+      bottomPadding: 10,
+      withLines: true
     });
   });
 

--- a/frontend/src/shelter/ShelterIntakeSummary.js
+++ b/frontend/src/shelter/ShelterIntakeSummary.js
@@ -11,6 +11,7 @@ import Header from '../components/Header';
 import { SystemErrorContext } from '../components/SystemError';
 import AnimalCards from '../components/AnimalCards';
 import { printIntakeSummaryAnimalCareSchedules } from './Utils';
+import { printOwnerDetails } from './Utils';
 
 function ShelterIntakeSummary({ id, incident }) {
 
@@ -27,6 +28,12 @@ function ShelterIntakeSummary({ id, incident }) {
     person: null,
     person_object: {first_name:'', last_name:''}
   });
+
+  const handlePrintOwnerClick = (e) => {
+    e.preventDefault();
+
+    printOwnerDetails(data.person_object);
+  }
 
   const handlePrintAllAnimalsClick = (e) => {
     e.preventDefault();
@@ -86,7 +93,34 @@ function ShelterIntakeSummary({ id, incident }) {
                 </ListGroup.Item>
                 {data.intake_type === 'owner_walkin' ?
                 <ListGroup.Item>
-                  <b>Owner:</b> <Link href={"/" + incident + "/people/owner/" + data.person} className="text-link" style={{textDecoration:"none", color:"white"}}>{data.person_object.first_name} {data.person_object.last_name}</Link>
+                  <b>Owner:</b>{' '}
+                  <Link
+                    href={"/" + incident + "/people/owner/" + data.person}
+                    className="text-link"
+                    style={{textDecoration:"none", color:"white"}}
+                  >
+                    {data.person_object.first_name}
+                    {' '}
+                    {data.person_object.last_name}
+                  </Link>
+                  <OverlayTrigger
+                    key={'printOwner'}
+                    placement="top"
+                    overlay={
+                      <Tooltip id={`tooltip-printall`}>
+                        Print Owner Details
+                      </Tooltip>
+                    }
+                  >
+                    <FontAwesomeIcon
+                      icon={faPrint}
+                      onClick={handlePrintOwnerClick}
+                      style={{cursor:'pointer'}}
+                      className="ml-2 fa-move-up"
+                      size="sm"
+                      inverse
+                    />
+                  </OverlayTrigger>
                 </ListGroup.Item>
                 : data.intake_type === 'reporter_walkin' ?
                 <ListGroup.Item>

--- a/frontend/src/shelter/Utils.js
+++ b/frontend/src/shelter/Utils.js
@@ -1,6 +1,8 @@
 import moment from 'moment';
 import { buildAnimalCareScheduleDoc } from '../animals/Utils';
 
+export { printOwnerDetails } from '../people/Utils';
+
 const dateFormat = 'YYYYMMDDHHmm';
 
 export const printRoomAnimalCareSchedules  = async (animals = [], roomId = 0) => {

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -178,7 +178,7 @@ class ShelterlyPDF {
     // add logo header
     this.#jsPDF.addImage(
       logo,
-      "png",
+      'png',
       this.#documentTopMargin,
       this.#documentLeftMargin,
       50,
@@ -187,7 +187,7 @@ class ShelterlyPDF {
 
     // text brown
     this.setDocumentColors({ rgb: rgbColors.SHELTERLY_BROWN });
-    this.#jsPDF.text("SHELTERLY", this.#documentLeftMargin, 80);
+    this.#jsPDF.text('SHELTERLY', this.#documentLeftMargin, 80);
 
     // reset doc colors
     this.setDocumentColors();
@@ -198,7 +198,7 @@ class ShelterlyPDF {
       pageTitle,
       this.pageWidth - this.#documentRightMargin,
       this.#documentTopMargin,
-      { align: "right" }
+      { align: 'right' }
     );
     this.#documentLastYPosition = this.#documentTopMargin + 25;
 
@@ -208,7 +208,7 @@ class ShelterlyPDF {
         subtitle,
         this.pageWidth - this.#documentRightMargin,
         this.#documentLastYPosition,
-        { align: "right" }
+        { align: 'right' }
       );
     }
 
@@ -408,7 +408,7 @@ class ShelterlyPDF {
 
     let _xPosition = xPosition;
 
-    textArray.map((_text, i) => {
+    textArray.forEach((_text, i) => {
       this.#jsPDF.setFont(undefined, 'bold');
 
       if (i % 2 === 0) {
@@ -694,6 +694,17 @@ class ShelterlyPDF {
     });
 
     this.resetDocumentLeftMargin();
+  }
+
+  drawPageNumbers({
+    pageNumber,
+    pageCount
+  }) {
+    const jsPdf = this.#jsPDF;
+    const { width: pageWidth, height: pageHeight } = jsPdf.internal.pageSize;
+    jsPdf.text('Page ' + String(pageNumber) + ' of ' + String(pageCount), pageWidth / 2, pageHeight - 15, {
+        align: 'center'
+      });
   }
 
   /**

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -16,6 +16,10 @@ const rgbColors = {
   WHITE: [255, 255, 255]
 }
 
+const handlerTypes = {
+  DEFAULT: 'default'
+}
+
 class ShelterlyPDF {
   // private properties
   #jsPDF;
@@ -64,6 +68,8 @@ class ShelterlyPDF {
     }
     if (typeof addFooterHandler === 'function') {
       this.#addFooter = addFooterHandler;
+    } else if (addFooterHandler === ShelterlyPDF.HandlerTypes.DEFAULT) {
+      this.#addFooter = this.drawPageNumbers;
     }
 
     // document defaults
@@ -71,6 +77,11 @@ class ShelterlyPDF {
 
     // draw header
     this.drawPageHeader();
+  }
+
+  // static getters
+  static get HandlerTypes() {
+    return handlerTypes;
   }
 
   // read/write properties

--- a/frontend/src/utils/pdf.js
+++ b/frontend/src/utils/pdf.js
@@ -14,11 +14,17 @@ const rgbColors = {
   SHELTERLY_BROWN: [139, 107, 82],
   DEFAULT: [0, 0, 0],
   WHITE: [255, 255, 255]
-}
+};
 
 const handlerTypes = {
   DEFAULT: 'default'
-}
+};
+
+const alignTypes = {
+  LEFT: 'left',
+  CENTER: 'center',
+  RIGHT: 'right'
+};
 
 class ShelterlyPDF {
   // private properties
@@ -84,7 +90,14 @@ class ShelterlyPDF {
     return handlerTypes;
   }
 
+  static get AlignTypes() {
+    return alignTypes;
+  }
+
+  //
   // read/write properties
+  //
+
   get fileName() { return this.#fileName; }
   set fileName(value) { this.#fileName = value; }
 
@@ -94,12 +107,20 @@ class ShelterlyPDF {
   get documentLeftMargin() { return this.#documentLeftMargin; }
   set documentLeftMargin(value) { this.#documentLeftMargin = value; }
 
+  //
   // read only properties
+  //
+
   get fileExtension() { return this.#fileExtension; }
   get pageHeight() { return this.#jsPDF.internal.pageSize.height || this.#jsPDF.internal.pageSize.getHeight(); }
   get pageWidth() { return this.#jsPDF.internal.pageSize.width || this.#jsPDF.internal.pageSize.getWidth(); }
   get numberOfPages() { return this.#jsPDF.internal.getNumberOfPages(); }
   get remainderPageHeight() { return (this.pageHeight - 35) - this.#documentLastYPosition - 20; }
+  get contentWidth() { return this.pageWidth - this.#defaultXMargin * 2; }
+
+  //
+  // document config methods
+  //
 
   /**
    * sets the text and draw colors
@@ -155,7 +176,7 @@ class ShelterlyPDF {
   }
 
   //
-  // draw methods
+  // document draw methods
   //
 
   /**
@@ -381,14 +402,25 @@ class ShelterlyPDF {
   drawSectionHeader({
     text,
     hRule = false,
-    fontSize = this.#documentTitle2FontSize
+    fontSize = this.#documentTitle2FontSize,
+    align = alignTypes.LEFT
   } = {}) {
     const yPosition = this.beforeDraw({ yPosition: this.getLastYPositionWithBuffer({ buffer: 25 }) });
     this.setDocumentFontSize({ size: fontSize });
-    this.#jsPDF.text(text, this.#documentLeftMargin, yPosition);
 
-    // set last y position
+    const textWidth = this.#jsPDF.getStringUnitWidth(text);
+    let leftMargin = this.#documentLeftMargin;
+    if (align === alignTypes.CENTER) {
+      leftMargin = this.contentWidth / 2 - textWidth * 2 - 15;
+    } else if (align === alignTypes.RIGHT) {
+      leftMargin = this.contentWidth - textWidth - 15;
+    }
+
+    this.#jsPDF.text(text, leftMargin, yPosition);
+
+    // set x & y position
     this.#documentLastYPosition = yPosition - 20;
+    this.#documentLeftMargin = this.#defaultXMargin;
 
     if (hRule) {
       this.drawPad();
@@ -535,7 +567,9 @@ class ShelterlyPDF {
       size = 0,
       marginTop = 0,
       inlineRightMargin = 0,
-      inlineOffset = 0
+      inlineOffset = 0,
+      withLines = false,
+      lineXOffset = 0
     }, i) => {
       const yPosition = this.getLastYPositionWithBuffer() + marginTop;
       this.#jsPDF.setFillColor(...fillColor);
@@ -551,6 +585,15 @@ class ShelterlyPDF {
       }
 
       if (listStyle === 'grid') {
+        if (withLines === true) {
+          const textWidth = this.#jsPDF.getStringUnitWidth(label) * this.#documentFontSize;
+          this.#jsPDF.line(
+            this.#documentLeftMargin + textWidth,
+            yPosition + 15,
+            this.#documentLeftMargin + this.pageWidth / 2 - 30,
+            yPosition + 15
+          );
+        }
         if (i % 2 === 0) {
           this.#documentLeftMargin = this.pageWidth / 2;
         } else {
@@ -620,8 +663,8 @@ class ShelterlyPDF {
     this.drawList({
       listStyle,
       listItems: labels.map((label) => ({
-        label,
-        type: 'checkbox',
+        label: label.label || label,
+        type: label.type || 'checkbox',
         size: 20
       })),
       bottomPadding
@@ -629,6 +672,7 @@ class ShelterlyPDF {
   }
   /**
    * draw a text list
+   *
    * @param  {number} [bottomPadding=0] - bottom padding after list is drawn
    * @param  {number} [labelInlineMarginRight=0] - right margin of inline label/list item
    * @param  {number} [labelInlineOffset=0] - offset for inline style
@@ -642,7 +686,8 @@ class ShelterlyPDF {
     labelInlineOffset = 0,
     labelMarginTop = 0,
     labels = [],
-    listStyle = 'block'
+    listStyle = 'block',
+    withLines = false,
   }) {
     this.drawList({
       listStyle,
@@ -650,7 +695,8 @@ class ShelterlyPDF {
         label,
         marginTop: labelMarginTop,
         inlineRightMargin: labelInlineMarginRight,
-        inlineOffset: labelInlineOffset
+        inlineOffset: labelInlineOffset,
+        withLines
       })),
       bottomPadding
     })
@@ -658,6 +704,7 @@ class ShelterlyPDF {
 
   /**
    * draws a blank table grid with headers
+   *
    * @param  {Array} [headers=[' ', ' ', ' ', ' ']] - column headers
    */
   drawTableGrid({
@@ -707,6 +754,13 @@ class ShelterlyPDF {
     this.resetDocumentLeftMargin();
   }
 
+  /**
+   * draws page numbers and total page count at the footer of the document
+   *
+   * @param {object} param0
+   * @param {number} param0.pageNumber
+   * @param {number} param0.pageCount
+   */
   drawPageNumbers({
     pageNumber,
     pageCount
@@ -719,9 +773,10 @@ class ShelterlyPDF {
   }
 
   /**
-   * 
+   * saves the document to file
+   *
    * @param {object} [param0]
-   * @param {number} [maxPages=Infinity]
+   * @param {number} [maxPages=Infinity] limits the amount of pages to save
    * @returns {Promise<void>}
    */
   saveFile({

--- a/shelter/serializers.py
+++ b/shelter/serializers.py
@@ -107,8 +107,8 @@ class IntakeSummarySerializer(serializers.ModelSerializer):
         return ModestAnimalSerializer(obj.animals, many=True).data
 
     def get_person_object(self, obj):
-        from people.serializers import SimplePersonSerializer
-        return SimplePersonSerializer(obj.person, required=False, read_only=True).data
+        from people.serializers import PersonSerializer
+        return PersonSerializer(obj.person, required=False, read_only=True).data
 
     class Meta:
         model = IntakeSummary


### PR DESCRIPTION
With this change, owner paging is now compartmentalized per owner, so if you are printing many owners, the page numbers will be 1 of {total_pages_per_owner} instead of 1 of {total_pages}. Test this out with owners with little pages, lots of pages, and everything in between.

The main request, adding the liability language at the end of the owner form, is also included, tacked on at the end of each owner. 