### PR TITLE
[Issue #561] lazy loads image into data strings to prevent double loading

### DIFF
--- a/frontend/src/animals/AnimalSearch.js
+++ b/frontend/src/animals/AnimalSearch.js
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useRef } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import axios from "axios";
 import { Link, useQueryParams } from 'raviger';
-import { Button, Card, CardGroup, Col, Collapse, Form, FormControl, InputGroup, ListGroup, OverlayTrigger, Pagination, Row, Tooltip } from 'react-bootstrap';
+import { Button, Card, CardGroup, Col, Collapse, Form, FormControl, InputGroup, ListGroup, OverlayTrigger, Pagination, Row, Spinner, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faBan, faCalendarDay, faClipboardList, faCut, faEnvelope, faLink, faMapMarkerAlt, faMedkit, faPrint, faUserAltSlash
@@ -15,7 +15,7 @@ import Moment from 'react-moment';
 import Select, { components } from 'react-select';
 import L from "leaflet";
 import { Circle, Map, Marker, Tooltip as MapTooltip, TileLayer } from "react-leaflet";
-import { useMark, useSubmitting } from '../hooks';
+import { useMark, useSubmitting, useDataImg } from '../hooks';
 import Header from '../components/Header';
 import Scrollbar from '../components/Scrollbars';
 import { titleCase } from '../components/Utils';
@@ -26,9 +26,9 @@ import AnimalCoverImage from '../components/AnimalCoverImage';
 import { printAnimalCareSchedule, printAllAnimalCareSchedules } from './Utils';
 import { SystemErrorContext } from '../components/SystemError';
 import ButtonSpinner from '../components/ButtonSpinner';
+import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
 
 import '../assets/styles.css';
-import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
 
 const NoOptionsMessage = props => {
   return (
@@ -91,6 +91,21 @@ function AnimalSearch({ incident }) {
     submittingComplete,
     submittingLabel
   } = useSubmitting();
+  const { promiseImage, getBase64Image } = useDataImg();
+  const [lazyAnimalImages, setLazyAnimalImages] = useState([]);
+
+  function findLazyAnimalImage (animalId) {
+    return lazyAnimalImages.find((lazyAnimal) => lazyAnimal.id === animalId);
+  }
+  function addLazyAnimalImage (animalId, animalImage) {
+    setLazyAnimalImages((prevState) => {
+      prevState.push({
+        id: animalId,
+        image: animalImage
+      });
+      return prevState;
+    })
+  }
 
   const colorChoices = {'':[], 'dog':dogColorChoices, 'cat':catColorChoices, 'horse':horseColorChoices, 'other':otherColorChoices}
 
@@ -141,7 +156,7 @@ function AnimalSearch({ incident }) {
 
   const handleDownloadPdfClick = (animalId) => {
     const animal = animals.find((animal) => animal.id === animalId);
-    printAnimalCareSchedule(animal, [animal.front_image]);
+    printAnimalCareSchedule(animal);
   }
 
   const handlePrintAllClick = (e) => {
@@ -216,22 +231,35 @@ function AnimalSearch({ incident }) {
       await axios.get('/animals/api/animal/?search=' + searchTerm +'&incident=' + incident, {
         cancelToken: source.token,
       })
-      .then(response => {
+      .then(async (response) => {
         if (!unmounted) {
           setNumPages(Math.ceil(response.data.length / ITEMS_PER_PAGE));
           setData({animals: response.data, isFetching: false});
           setAnimals(response.data);
+          
+          // highlight search terms
+          markInstances(searchTerm);
+          handleApplyFilters(response.data);
+
           let bounds_array = [];
+
           for (const animal of response.data) {
             if (animal.latitude && animal.longitude) {
               bounds_array.push([animal.latitude, animal.longitude]);
             }
-          }
-          setBounds(bounds_array.length > 0 ? L.latLngBounds(bounds_array) : L.latLngBounds([[0,0]]));
 
-          // highlight search terms
-          markInstances(searchTerm);
-          handleApplyFilters(response.data);
+            // lazy load animal front_image
+            const lazyAnimalImage = findLazyAnimalImage(animal.id);
+            if (lazyAnimalImage?.image) {
+              animal.lazyImage = lazyAnimalImage.image
+            } else if (animal.front_image) {
+              const imgData = await promiseImage(animal.front_image);
+              animal.lazyImage = imgData;
+              addLazyAnimalImage(animal.id, imgData);
+            }
+          }
+          setAnimals(response.data);
+          setBounds(bounds_array.length > 0 ? L.latLngBounds(bounds_array) : L.latLngBounds([[0,0]]));
         }
       })
       .catch(error => {
@@ -507,11 +535,23 @@ function AnimalSearch({ incident }) {
           </div>
           <CardGroup>
             <Card style={{maxWidth:"206px", maxHeight:"206px"}}>
-              <Card.Body className="p-0 m-0">
-                <AnimalCoverImage
-                  animalSpecies={animal.species}
-                  animalImageSrc={animal.front_image}
-                />
+              <Card.Body className="p-0 m-0 d-flex justify-content-center align-items-center">
+                {animal.front_image && !animal.lazyImage
+                  ? (
+                    <Spinner animation="border" role="status">
+                      <span className="visually-hidden">Loading Image...</span>
+                    </Spinner>
+                  )
+                : (
+                  <AnimalCoverImage
+                    animalSpecies={animal.species}
+                    animalImageSrc={
+                      animal.lazyImage
+                        ? `data:image/png;base64,${getBase64Image(animal.lazyImage)}`
+                        : animal.front_image
+                    }
+                  />
+                )}
               </Card.Body>
             </Card>
             <Card style={{marginBottom:"6px", maxWidth:"335px"}}>

--- a/frontend/src/animals/Utils.js
+++ b/frontend/src/animals/Utils.js
@@ -20,7 +20,14 @@ async function buildAnimalCareScheduleContent(pdf, animals) {
       padding: [10, 0, 10, 50],
       drawFuncName: 'drawImage'
     };
-    if (imageSrc) {
+    if (animal.lazyImage) {
+      graphicOptions = {
+        ...graphicOptions,
+        src: animal.lazyImage,
+        drawFuncName: 'drawGraphic'
+      };
+    }
+    else if (imageSrc) {
       graphicOptions = {
         ...graphicOptions,
         src: imageSrc

--- a/frontend/src/assets/styles.css
+++ b/frontend/src/assets/styles.css
@@ -21,3 +21,7 @@
 .print-all-btn-icon:hover .fa-print {
   color: #222!important;
 }
+
+.visually-hidden {
+  visibility: hidden;
+}

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -1,3 +1,4 @@
-export { default as useMark } from "./useMark";
-export { default as useSubmitting } from "./useSubmitting";
-export { default as useDateRange } from "./useDateRange";
+export { default as useMark } from './useMark';
+export { default as useSubmitting } from './useSubmitting';
+export { default as useDateRange } from './useDateRange';
+export { default as useDataImg } from  './useDataImg';

--- a/frontend/src/hooks/useDataImg.js
+++ b/frontend/src/hooks/useDataImg.js
@@ -1,0 +1,66 @@
+/**
+ * Hook for loading an image from src path to base64 encoded data string
+ */
+function useDataImg() {
+  /**
+   * Promise that loads the image form source path
+   *
+   * @param {string} src
+   * @returns {Image}
+   */
+  async function promiseImage(src){
+    return new Promise((resolve, reject) => {
+      let img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.onload = () => resolve(img);
+      img.onerror = reject;
+      img.src = src;
+    });
+  }
+
+  /**
+   * Returns a base64 encoded data url string of the supplied Image
+   *
+   * @param {Image} img
+   * @returns {string}
+   */
+  function getBase64Image(img) {
+    // Create an empty canvas element
+    var canvas = document.createElement("canvas");
+    canvas.width = img.width;
+    canvas.height = img.height;
+
+    // Copy the image contents to the canvas
+    var ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+
+    // Get the data-URL formatted image
+    // Firefox supports PNG and JPEG. You could check img.src to
+    // guess the original format, but be aware the using "image/jpg"
+    // will re-encode the image.
+    var dataURL = canvas.toDataURL("image/png");
+
+    return dataURL.replace(/^data:image\/(png|jpg);base64,/, "");
+  }
+
+  /**
+   * Combines promiseImage and getBase64Image to get the url string of the image src supplied at hook instantiation
+   *
+   * @param {string} imgSrc provide an image path
+   * @returns {string} base64 encoded data url string
+   */
+  async function getDataFromSrcPath(imgSrc) {
+    const img = await promiseImage(imgSrc);
+    const imgData = getBase64Image(img);
+
+    return imgData;
+  }
+
+  return {
+    getDataFromSrcPath,
+    promiseImage,
+    getBase64Image
+  }
+}
+
+export default useDataImg;


### PR DESCRIPTION
Implemented on animal search.

To test:

- open the network drawer for inspection on your favorite browser
- visit animal search, here you can filter and print all, print some, print one, however you like, do it all
- you should notices images load from network once, and any other times they will load as a data string which comes from from state

This does reduce bandwidth usage, however it does put more strain on the client, like more data in memory, weak clients will drag. Needs plenty of testing, especially to see how this loads with many images in the system.