### PR TITLE
fixes image compression on animal image upload

### DIFF
--- a/frontend/src/animals/AnimalForm.js
+++ b/frontend/src/animals/AnimalForm.js
@@ -311,8 +311,15 @@ const AnimalForm = (props) => {
             }
           }
           // Add extra images.
-          for (let i = 0; i < extra_images.length; i++) {
-            formData.append('extra' + (i + 1), extra_images[i].file);
+          for (let i = 0; i < values.extra_images.length; i++) {
+            const extraKey = `extra${(i + 1)}`;
+            const extraImage = values.extra_images[i];
+            const extraName = extraImage.name;
+            if (extraName) {
+              formData.append(extraKey, extraImage, extraName);
+            } else {
+              formData.append(extraKey, extraImage);
+            }
           }
 
           if (is_workflow) {


### PR DESCRIPTION
Fixes image compression on image upload. 

- For the main images (front and side) those were being compressed, but the data_url of the uncompressed image was being appended to the form data. I am not sure why the data_url's are being appended, seems to be part of workflow stuff, so I made sure it still works for backwards compatibility, using the data url from the compressed image file instead.
- For the extra images, compression was disabled, likely because the dynamic natural of the control, but i fixed that up.
- I've also set the compression to 1mb instead of 2mb, we have server limit of 10mb limit of post data, and hypothetically at 2mb per image, a user could get hit with that limit without knowing what happened. Under 1mb will keep us clear of that limit, while saving even more bandwidth for the user.

Closes #646 