### PR TITLE
Issues/556 disable data dependant buttons

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.npmrc

--- a/frontend/src/animals/AnimalDetails.js
+++ b/frontend/src/animals/AnimalDetails.js
@@ -18,12 +18,14 @@ import { printAnimalCareSchedule } from './Utils';
 import AnimalCoverImage from '../components/AnimalCoverImage';
 import { SystemErrorContext } from '../components/SystemError';
 import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
+import LoadingLink from '../components/LoadingLink';
 
 function AnimalDetails({ id, incident, organization }) {
 
   const { state } = useContext(AuthContext);
   const { setShowSystemError } = useContext(SystemErrorContext);
   const [images, setImages] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   // Initial animal data.
   const [data, setData] = useState({
@@ -66,6 +68,7 @@ function AnimalDetails({ id, incident, organization }) {
 
   // Handle animal reunited submit.
   const handleSubmit = async () => {
+    setIsLoading(true);
     await axios.patch('/animals/api/animal/' + id + '/', {status:'REUNITED', shelter:null, room:null})
     .then(response => {
       setData(response.data);
@@ -73,11 +76,13 @@ function AnimalDetails({ id, incident, organization }) {
     })
     .catch(error => {
       setShowSystemError(true);
-    });
+    })
+    .finally(() => setIsLoading(false));
   }
 
   // Handle remove owner submit.
   const handleOwnerSubmit = async () => {
+    setIsLoading(true);
     await axios.patch('/animals/api/animal/' + id + '/', {remove_owner:ownerToDelete.id})
     .then(response => {
       setData(prevState => ({ ...prevState, "owners":prevState.owners.filter(owner => owner.id !== ownerToDelete.id) }));
@@ -85,11 +90,13 @@ function AnimalDetails({ id, incident, organization }) {
     })
     .catch(error => {
       setShowSystemError(true);
-    });
+    })
+    .finally(() => setIsLoading(false));
   }
 
   // Handle animal removal submit.
   const handleAnimalSubmit = async () => {
+    setIsLoading(true);
     await axios.patch('/animals/api/animal/' + id + '/', {remove_animal:id})
     .then(response => {
       handleAnimalClose();
@@ -108,7 +115,8 @@ function AnimalDetails({ id, incident, organization }) {
     })
     .catch(error => {
       setShowSystemError(true);
-    });
+    })
+    .finally(() => setIsLoading(false));
   }
 
   const handleDownloadPdfClick = () =>
@@ -118,6 +126,7 @@ function AnimalDetails({ id, incident, organization }) {
   useEffect(() => {
     let unmounted = false;
     let source = axios.CancelToken.source();
+    setIsLoading(true);
     const fetchAnimalData = async () => {
       // Fetch Animal data.
       await axios.get('/animals/api/animal/' + id + '/', {
@@ -135,7 +144,8 @@ function AnimalDetails({ id, incident, organization }) {
         if (!unmounted) {
           setShowSystemError(true);
         }
-      });
+      })
+      .finally(() => setIsLoading(false));
     };
     fetchAnimalData();
     // Cleanup.
@@ -148,7 +158,7 @@ function AnimalDetails({ id, incident, organization }) {
   return (
     <>
     <Header>
-      Animal #{data.id}
+      Animal #{data.id || ' - '}
       <OverlayTrigger
         key={"edit"}
         placement="bottom"
@@ -166,19 +176,22 @@ function AnimalDetails({ id, incident, organization }) {
         tooltipPlacement='bottom'
         tooltipText='Print Animal Care Schedule'
         printFunc={handleDownloadPdfClick}
+        disabled={isLoading}
       />
       {data.status !== 'REUNITED' ?
-      <OverlayTrigger
-        key={"reunite"}
-        placement="bottom"
-        overlay={
-          <Tooltip id={`tooltip-reunite`}>
-            Reunite animal
-          </Tooltip>
-        }
-      >
-        <FontAwesomeIcon icon={faHomeHeart} onClick={() => setShow(true)} className="mr-1" style={{cursor:'pointer'}} inverse />
-      </OverlayTrigger>
+        <OverlayTrigger
+          key={"reunite"}
+          placement="bottom"
+          overlay={
+            <Tooltip id={`tooltip-reunite`}>
+              Reunite animal
+            </Tooltip>
+          }
+        >
+          <LoadingLink onClick={() => setShow(true)} isLoading={isLoading}>
+            <FontAwesomeIcon icon={faHomeHeart} className="mr-1" style={{cursor:'pointer'}} inverse />
+          </LoadingLink>
+        </OverlayTrigger>
       : ""}
       <OverlayTrigger
         key={"vetrequest"}
@@ -200,7 +213,9 @@ function AnimalDetails({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <FontAwesomeIcon icon={faTimes} style={{cursor:'pointer'}} onClick={() => {setShowAnimalConfirm(true);}} className="ml-1" size="lg" inverse />
+        <LoadingLink onClick={() => {setShowAnimalConfirm(true);}} isLoading={isLoading}>
+          <FontAwesomeIcon icon={faTimes} style={{cursor:'pointer'}} className="ml-1" size="lg" inverse />
+        </LoadingLink>
       </OverlayTrigger>
     </Header>
     <hr/>

--- a/frontend/src/animals/AnimalDetails.js
+++ b/frontend/src/animals/AnimalDetails.js
@@ -168,7 +168,12 @@ function AnimalDetails({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <Link href={"/" + organization + "/" + incident + "/animals/edit/" + id} ><FontAwesomeIcon icon={faEdit} className="ml-2" inverse /></Link>
+        <LoadingLink
+          href={"/" + organization + "/" + incident + "/animals/edit/" + id}
+          isLoading={isLoading}
+        >
+          <FontAwesomeIcon icon={faEdit} className="ml-2" inverse />
+        </LoadingLink>
       </OverlayTrigger>
       <ShelterlyPrintifyButton
         id="animal-details-animal-care-schedule"
@@ -202,7 +207,12 @@ function AnimalDetails({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <Link href={"/" + organization + "/" + incident + "/animals/" + id + "/vetrequest/new"} ><FontAwesomeIcon icon={faUserDoctorMessage} className="mr-1 ml-1" inverse /></Link>
+        <LoadingLink
+          href={"/" + organization + "/" + incident + "/animals/" + id + "/vetrequest/new"}
+          isLoading={isLoading}
+        >
+          <FontAwesomeIcon icon={faUserDoctorMessage} className="mr-1 ml-1" inverse />
+        </LoadingLink>
       </OverlayTrigger>
       <OverlayTrigger
         key={"cancel-animal"}

--- a/frontend/src/components/LoadingLink.js
+++ b/frontend/src/components/LoadingLink.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'raviger';
+
+const LoadingLink = ({
+  as = Link,
+  isLoading = true,
+  loadingClassName = 'text-dark',
+  children,
+  href = '',
+  ...rest
+}) => {
+  const LinkComponent = as;
+  if (isLoading) {
+    const NoLink = () =>
+      React.Children.map(children, child =>
+        React.cloneElement(child, {
+          className: `${child.props.className} ${loadingClassName}`
+        })
+      );
+    return <NoLink />;
+  }
+  return (
+    <LinkComponent href={href} {...rest}>
+      {children}
+    </LinkComponent>
+  )
+};
+
+export default LoadingLink;

--- a/frontend/src/components/ShelterlyPrintifyButton.js
+++ b/frontend/src/components/ShelterlyPrintifyButton.js
@@ -12,7 +12,9 @@ const ShelterlyPrintifyButton = ({
   spinnerSize = 1.5,
   id = 'shelterly-printify-button',
   tooltipPlacement = 'bottom',
-  tooltipText = 'Printify'
+  tooltipText = 'Printify',
+  disabled = false,
+  disabledClassName = 'text-dark'
 }) => {
   const {
     isSubmitting,
@@ -22,6 +24,7 @@ const ShelterlyPrintifyButton = ({
 
   const handleClick = (e) => {
     e.preventDefault();
+    if (disabled) return;
 
     handleSubmitting()
       .then(printFunc)
@@ -57,7 +60,7 @@ const ShelterlyPrintifyButton = ({
           }}
           {...triggerHandler}
         >
-          <span ref={ref} data-testid="icon-test-component"><FontAwesomeIcon icon={faPrint} inverse /></span>
+          <span ref={ref} data-testid="icon-test-component"><FontAwesomeIcon icon={faPrint} className={`${disabled ? disabledClassName : ''}`} inverse /></span>
         </ButtonSpinner>
       )}
     </OverlayTrigger>

--- a/frontend/src/components/__tests__/LoadingLink.test.js
+++ b/frontend/src/components/__tests__/LoadingLink.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import {
+  render,
+} from "@testing-library/react";
+import LoadingLink from "../LoadingLink";
+
+describe('Components > LoadingLink', () => {
+  it('renders only children of LoadingLink in default state', () => {
+    const { getByTestId, queryByTestId } = render(
+      <LoadingLink data-testid="loading-link-test">
+        <span data-testid="loading-link-children">Hello</span>
+      </LoadingLink>
+    )
+    expect(queryByTestId('loading-link-test')).not.toBeInTheDocument();
+    expect(getByTestId('loading-link-children')).toBeInTheDocument();
+  });
+
+  it('should render LoadingLink with children in non-loading state', () => {
+    const { getByTestId } = render(
+      <LoadingLink data-testid="loading-link-test" isLoading={false}>
+        <span data-testid="loading-link-children">Hello</span>
+      </LoadingLink>
+    )
+    expect(getByTestId('loading-link-test')).toBeInTheDocument();
+    expect(getByTestId('loading-link-children')).toBeInTheDocument();
+  })
+});

--- a/frontend/src/components/__tests__/ShelterlyPrintifyButton.test.js
+++ b/frontend/src/components/__tests__/ShelterlyPrintifyButton.test.js
@@ -55,4 +55,26 @@ describe('Components > ShelterlyPrintifyButton', () => {
       expect(clickHandlerMock).toHaveBeenCalledTimes(1);
     });
   });
+
+  it('should not call clickHandler when button is clicked but disabled', async () => {
+    const clickHandlerMock = jest.fn()
+    const { getByTestId } = render(
+      <ShelterlyPrintifyButton
+        printFunc={clickHandlerMock}
+        tooltipText="Tooltip text"
+        disabled={true}
+      />
+    );
+
+    // Find the button element
+    const buttonElement = getByTestId('button-test-component');
+
+    // Click the button
+    fireEvent.click(buttonElement);
+
+    // Wait for the Promise to resolve (clickHandler to be called)
+    await wait(() => {
+      expect(clickHandlerMock).not.toHaveBeenCalledTimes(1);
+    });
+  })
 });

--- a/frontend/src/dispatch/DispatchSummary.js
+++ b/frontend/src/dispatch/DispatchSummary.js
@@ -253,6 +253,7 @@ function DispatchSummary({ id, incident, organization }) {
         tooltipPlacement='bottom'
         tooltipText='Print Dispatch Assignment'
         printFunc={handleDownloadPdfClick}
+        disabled={isLoading}
       />
 
       {data.end_time ?
@@ -265,7 +266,12 @@ function DispatchSummary({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <Link href={"/" + organization + "/" + incident + "/dispatch/resolution/" + id}><FontAwesomeIcon icon={faEdit} inverse /></Link>
+        <LoadingLink
+          href={"/" + organization + "/" + incident + "/dispatch/resolution/" + id}
+          isLoading={isLoading}
+        >
+          <FontAwesomeIcon icon={faEdit} inverse />
+        </LoadingLink>
       </OverlayTrigger>
       :
       <OverlayTrigger
@@ -277,7 +283,12 @@ function DispatchSummary({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <Link href={"/" + organization + "/" + incident + "/dispatch/resolution/" + id}><FontAwesomeIcon icon={faClipboardCheck} inverse /></Link>
+        <LoadingLink
+          href={"/" + organization + "/" + incident + "/dispatch/resolution/" + id}
+          isLoading={isLoading}
+        >
+          <FontAwesomeIcon icon={faClipboardCheck} inverse />
+        </LoadingLink>
       </OverlayTrigger>
       }
       <OverlayTrigger

--- a/frontend/src/hotline/ServiceRequestDetails.js
+++ b/frontend/src/hotline/ServiceRequestDetails.js
@@ -17,11 +17,12 @@ import PhotoDocuments from '../components/PhotoDocuments';
 import { SystemErrorContext } from '../components/SystemError';
 import { printServiceRequestSummary, printSrAnimalCareSchedules } from './Utils'
 import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
+import LoadingLink from '../components/LoadingLink';
 
 import '../assets/styles.css';
 
 function ServiceRequestDetails({ id, incident, organization }) {
-
+  const [isLoading, setIsLoading] = useState(true);
   const { setShowSystemError } = useContext(SystemErrorContext);
 
   const datetime = useRef(null);
@@ -33,7 +34,9 @@ function ServiceRequestDetails({ id, incident, organization }) {
 
   const [showModal, setShowModal] = useState(false);
   const cancelServiceRequest = () => {
+    setIsLoading(true);
     axios.patch('/hotline/api/servicerequests/' + id + '/', {status:'canceled'})
+      .finally(() => setIsLoading(false));
     setData(prevState => ({ ...prevState, 'status':'Canceled', 'animals':prevState['animals'].map(animal => ({...animal, status:'CANCELED'}))}));
     setShowModal(false)
   }
@@ -79,6 +82,7 @@ function ServiceRequestDetails({ id, incident, organization }) {
 
   // Handle animal reunification submit.
   const handleSubmit = async () => {
+    setIsLoading(true);
     await axios.patch('/hotline/api/servicerequests/' + id + '/', {reunite_animals:true})
     .then(response => {
       setData(prevState => ({ ...prevState, "status":"Closed", "animals":prevState['animals'].map(animal => ({...animal, status:animal.status !== 'DECEASED' ? 'REUNITED' : 'DECEASED'})) }));
@@ -86,7 +90,8 @@ function ServiceRequestDetails({ id, incident, organization }) {
     })
     .catch(error => {
       setShowSystemError(true);
-    });
+    })
+    .finally(() => setIsLoading(false));
   }
 
   const handleDownloadPdfClick = () =>
@@ -109,6 +114,7 @@ function ServiceRequestDetails({ id, incident, organization }) {
   useEffect(() => {
     let unmounted = false;
     let source = axios.CancelToken.source();
+    setIsLoading(true);
 
     const fetchServiceRequestData = async () => {
       // Fetch ServiceRequest data.
@@ -124,7 +130,8 @@ function ServiceRequestDetails({ id, incident, organization }) {
         if (!unmounted) {
           setShowSystemError(true);
         }
-      });
+      })
+      .finally(() => setIsLoading(false));
     };
     fetchServiceRequestData();
     // Cleanup.
@@ -137,7 +144,7 @@ function ServiceRequestDetails({ id, incident, organization }) {
   return (
     <>
       <Header>
-        Service Request #{data.id}
+        Service Request #{data.id || ' - '}
         <OverlayTrigger
           key={"edit-service-request"}
           placement="bottom"
@@ -159,7 +166,9 @@ function ServiceRequestDetails({ id, incident, organization }) {
             </Tooltip>
           }
         >
-          <Link onClick={handleGeoJsonDownload} href=""><FontAwesomeIcon icon={faDownload} className="mx-2"  inverse /></Link>
+          <LoadingLink onClick={handleGeoJsonDownload} isLoading={isLoading}>
+            <FontAwesomeIcon icon={faDownload} className="mx-2"  inverse />
+          </LoadingLink>
         </OverlayTrigger>
 
         <ShelterlyPrintifyButton
@@ -168,6 +177,7 @@ function ServiceRequestDetails({ id, incident, organization }) {
           tooltipPlacement='bottom'
           tooltipText='Download Service Request Summary'
           printFunc={handleDownloadPdfClick}
+          disabled={isLoading}
         />
 
         <OverlayTrigger
@@ -179,7 +189,9 @@ function ServiceRequestDetails({ id, incident, organization }) {
             </Tooltip>
           }
         >
-          <FontAwesomeIcon icon={faTimes} className="ml-1" size="lg" style={{cursor:'pointer'}} inverse onClick={() => {setShowModal(true)}}/>
+          <LoadingLink onClick={() => {setShowModal(true)}} isLoading={isLoading}>
+            <FontAwesomeIcon icon={faTimes} className="ml-1" size="lg" style={{cursor:'pointer'}} inverse />
+          </LoadingLink>
         </OverlayTrigger>
       </Header>
       <Modal show={showModal} onHide={() => setShowModal(false)}>

--- a/frontend/src/hotline/ServiceRequestDetails.js
+++ b/frontend/src/hotline/ServiceRequestDetails.js
@@ -154,7 +154,12 @@ function ServiceRequestDetails({ id, incident, organization }) {
             </Tooltip>
           }
         >
-          <Link href={"/" + organization + "/" + incident + "/hotline/servicerequest/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2" inverse /></Link>
+          <LoadingLink
+            href={"/" + organization + "/" + incident + "/hotline/servicerequest/edit/" + id}
+            isLoading={isLoading}
+          >
+            <FontAwesomeIcon icon={faEdit} className="ml-2" inverse />
+          </LoadingLink>
         </OverlayTrigger>
 
         <OverlayTrigger

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -22,11 +22,14 @@ function PersonDetails({id, incident, organization}) {
   // Determine if this is an owner or reporter when creating a Person.
   let is_owner = window.location.pathname.includes("owner")
 
+  const [isPersonLoading, setIsPersonLoading] = useState(true);
+  const [isOrgLoading, setIsOrgLoading] = useState(true);
   const [show, setShow] = useState(false);
   const handleClose = () => setShow(false);
 
   // Handle animal reunification submit.
   const handleSubmit = async () => {
+    setIsPersonLoading(true);
     await axios.patch('/people/api/person/' + id + '/', {reunite_animals:true})
     .then(response => {
       setData(prevState => ({ ...prevState, "animals":prevState['animals'].map(animal => ({...animal, status:animal.status !== 'DECEASED' ? 'REUNITED' : 'DECEASED'})) }));
@@ -34,7 +37,8 @@ function PersonDetails({id, incident, organization}) {
     })
     .catch(error => {
       setShowSystemError(true);
-    });
+    })
+    .finally(() => setIsPersonLoading(false));
   }
 
   const [data, setData] = useState({
@@ -80,6 +84,8 @@ function PersonDetails({id, incident, organization}) {
   useEffect(() => {
     let unmounted = false;
     let source = axios.CancelToken.source();
+    setIsPersonLoading(true);
+    setIsOrgLoading(true);
 
     const fetchPersonData = async () => {
       // Fetch Person data.
@@ -95,7 +101,8 @@ function PersonDetails({id, incident, organization}) {
         if (!unmounted) {
           setShowSystemError(true);
         }
-      });
+      })
+      .finally(() => setIsPersonLoading(false));
     };
     fetchPersonData();
 
@@ -113,7 +120,8 @@ function PersonDetails({id, incident, organization}) {
         if (!unmounted) {
           setShowSystemError(true);
         }
-      });
+      })
+      .finally(() => setIsOrgLoading(false));
     };
     fetchOrganizationData();
 
@@ -123,6 +131,8 @@ function PersonDetails({id, incident, organization}) {
       source.cancel();
     };
   }, [id, incident]);
+
+  const isLoading = isPersonLoading || isOrgLoading;
 
   return (
     <>
@@ -162,6 +172,7 @@ function PersonDetails({id, incident, organization}) {
         tooltipPlacement='bottom'
         tooltipText='Download Printable Owner Summary'
         printFunc={handleDownloadPdfClick}
+        disabled={isLoading}
       />
     </Header>
     <hr/>

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -13,6 +13,7 @@ import AnimalCards from '../components/AnimalCards';
 import PhotoDocuments from '../components/PhotoDocuments';
 import { SystemErrorContext } from '../components/SystemError';
 import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
+import LoadingLink from '../components/LoadingLink';
 import { printOwnerDetails, printOwnerAnimalCareSchedules } from './Utils';
 
 function PersonDetails({id, incident, organization}) {
@@ -148,7 +149,12 @@ function PersonDetails({id, incident, organization}) {
               </Tooltip>
             }
           >
-            <Link href={"/" + organization + "/" + incident + "/people/owner/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse /></Link>
+            <LoadingLink
+              href={"/" + organization + "/" + incident + "/people/owner/edit/" + id}
+              isLoading={isLoading}
+            >
+              <FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse />
+            </LoadingLink>
           </OverlayTrigger>
         </span>
       :
@@ -162,7 +168,12 @@ function PersonDetails({id, incident, organization}) {
               </Tooltip>
             }
           >
-            <Link href={"/" + organization + "/" + incident + "/people/reporter/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse /></Link>
+            <LoadingLink
+              href={"/" + organization + "/" + incident + "/people/reporter/edit/" + id}
+              isLoading={isLoading}
+            >
+              <FontAwesomeIcon icon={faEdit} className="ml-2 mr-1" inverse />
+            </LoadingLink>
           </OverlayTrigger>
         </span>
       }

--- a/frontend/src/vet/VetRequestDetails.js
+++ b/frontend/src/vet/VetRequestDetails.js
@@ -14,10 +14,11 @@ import {
 } from '@fortawesome/pro-solid-svg-icons';
 import Header from '../components/Header';
 import { SystemErrorContext } from '../components/SystemError';
+import LoadingLink from '../components/LoadingLink';
 import { AuthContext } from "../accounts/AccountsReducer";
 
 function VetRequestDetails({ id, incident, organization }) {
-
+  const [isLoading, setIsLoading] = useState(true);
   const { dispatch, state } = useContext(AuthContext);
   const { setShowSystemError } = useContext(SystemErrorContext);
 
@@ -39,6 +40,7 @@ function VetRequestDetails({ id, incident, organization }) {
   useEffect(() => {
     let unmounted = false;
     let source = axios.CancelToken.source();
+    setIsLoading(true);
 
     const fetchVetRequestData = async () => {
       // Fetch VetRequest Details data.
@@ -52,7 +54,8 @@ function VetRequestDetails({ id, incident, organization }) {
       })
       .catch(error => {
         setShowSystemError(true);
-      });
+      })
+      .finally(() => setIsLoading(false));
     };
     fetchVetRequestData();
     // Cleanup.
@@ -75,7 +78,12 @@ function VetRequestDetails({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <Link href={"/" + organization + "/" + incident + "/vet/vetrequest/edit/" + id}><FontAwesomeIcon icon={faEdit} className="ml-2" inverse /></Link>
+        <LoadingLink
+          href={"/" + organization + "/" + incident + "/vet/vetrequest/edit/" + id}
+          isLoading={isLoading}
+        >
+          <FontAwesomeIcon icon={faEdit} className="ml-2" inverse />
+        </LoadingLink>
       </OverlayTrigger> : ""}
       {data.status === 'Open' ? <OverlayTrigger
         key={"cancel-vet-request"}
@@ -86,7 +94,9 @@ function VetRequestDetails({ id, incident, organization }) {
           </Tooltip>
         }
       >
-        <FontAwesomeIcon icon={faTimes} className="ml-1" size="lg" style={{cursor:'pointer'}} inverse onClick={() => {setShowModal(true)}}/>
+        <LoadingLink onClick={() => {setShowModal(true)}} isLoading={isLoading}>
+          <FontAwesomeIcon icon={faTimes} className="ml-1" size="lg" style={{cursor:'pointer'}} inverse />
+        </LoadingLink>
       </OverlayTrigger> : ""}
     </Header>
     <hr/>


### PR DESCRIPTION
Applied the fix to the following areas:

- animal details
- owner details
- service requests
- dispatch summaries

Here is a visual of what it looks like on the animal details, note the " - " in place of the id number, i put this there instead of being empty to soften the jump that occurs once it loads.

<img width="961" alt="Screen Shot 2024-02-10 at 1 04 31 PM" src="https://github.com/trevorskaggs/shelterly/assets/1508574/a0ef448a-54fa-4ca0-9214-968e0552e56c">


Closes #556 