### PR TITLE
Preplanned Team default name check + Team N increment #413

### DIFF
--- a/frontend/src/dispatch/DispatchMap.js
+++ b/frontend/src/dispatch/DispatchMap.js
@@ -360,7 +360,8 @@ function Deploy({ incident, organization }) {
     };
 
     // Only fetch team member data first time.
-    if (teamData.options.length === 0) {
+    // or after triggering a refresh
+    if (teamData.options.length === 0 || triggerRefresh) {
       fetchTeamMembers();
     }
 
@@ -406,43 +407,7 @@ function Deploy({ incident, organization }) {
             .then(response => {
               // Stay on map and remove selected SRs if in Preplanning mode.
               if (preplan) {
-                setData(prevState => ({ ...prevState, "service_requests":data.service_requests.filter(sr => !values.service_requests.includes(String(sr.id))) }));
-                setTotalSelectedState({'REPORTED':{}, 'REPORTED (EVAC REQUESTED)':{}, 'REPORTED (SIP REQUESTED)':{}, 'SHELTERED IN PLACE':{}, 'UNABLE TO LOCATE':{}});
-                setSelectedCount({count:0, disabled:true});
-                setMapState(Object.keys(mapState).filter(key => !values.service_requests.includes(String(key)))
-                  .reduce((obj, key) => {
-                    obj[key] = mapState[key];
-                    return obj;
-                  }, {})
-                );
-                axios.get('/evac/api/dispatchteam/', {
-                  params: {
-                    map: true
-                  },
-                })
-                .then(response => {
-                  let team_names = [];
-                  let team_name = '';
-                  response.data.forEach(function(team) {
-                    team_names.push(team.name);
-                  });
-                  // Provide a default "TeamN" team name that hasn't already be used.
-                  let i = 1;
-                  let name = 'Preplanned '
-                  do {
-                    if (!team_names.includes(name + String(i))){
-                      team_name = name + String(i);
-                    }
-                    i++;
-                  }
-                  while (team_name === '');
-                  setTeamData({teams: response.data, options: [], isFetching: false});
-                  setTeamName(team_name);
-                })
-                .catch(error => {
-                  setTeamData({teams: [], options: [], isFetching: false});
-                  setShowSystemError(true);
-                });
+                setTriggerRefresh(true);
               }
               // Otherwise navigate to the DA Summary page.
               else {


### PR DESCRIPTION
- Check that the "Team N" or "Preplanned N" Team name increment is working as expected.
  - always uses lowest available number.
  - had to change the endpoint that grabs the teams since it wasn't including preplanned teams for the name.
- The default name checkbox on the edit team name form dispatch summary page.
  - It disables the text box, and sends `{ defaultname: true }` as payload to the endpoint.
  - That property goes into the void as the backend isn't prepared for it.
  - I believe in the past (2 years ago!!), the plan was to have @AlexMountain implement something for the backend here. Let me know if we want to add it into the scope here, and if so need details on what it should do.

More notes

I closed the old pull request here #505 in favor of starting anew.

Closes #413 