### PR TITLE
folds whitespace in printed DA

### DIFF
--- a/frontend/src/dispatch/Utils.js
+++ b/frontend/src/dispatch/Utils.js
@@ -102,7 +102,8 @@ const buildDispatchResolutionsDoc = (drs = []) => {
       pdf.drawPad(10);
     });
 
-    // end of summary
+    // end of summary page break
+    pdf.drawPageBreak();
 
     // loop through SR's and page break between each one
     data.assigned_requests.forEach((assigned_request, index) => {

--- a/frontend/src/dispatch/Utils.js
+++ b/frontend/src/dispatch/Utils.js
@@ -25,7 +25,7 @@ const buildDispatchResolutionsDoc = (drs = []) => {
     }
 
     // draw team section
-    pdf.drawSectionHeader({ text: data.team_object.name, hRule: false, fontSize: 12 });
+    pdf.drawSectionHeader({ text: data.team_object.name, hRule: false, fontSize: 14 });
     pdf.drawPad(10)
     pdf.setDocumentFontSize({ size: 10 });
     pdf.drawTextList({
@@ -48,10 +48,10 @@ const buildDispatchResolutionsDoc = (drs = []) => {
       // Summary page
       pdf.drawSectionHeader({
         text: `SR#${assigned_request.service_request_object.id_for_incident} - ${srPriority.label} Priority`,
-        fontSize: 12
+        fontSize: 14
       });
 
-      pdf.drawPad(15);
+      pdf.drawPad(10);
 
       // status
       pdf.drawWrappedText({
@@ -60,8 +60,8 @@ const buildDispatchResolutionsDoc = (drs = []) => {
       });
 
       // summary address
-      pdf.drawSectionHeader({ text: 'Service Request Address:', fontSize: 12 });
-      pdf.drawPad(15);
+      pdf.drawSectionHeader({ text: 'Service Request Address:', fontSize: 14 });
+      pdf.drawPad(10);
 
       const [addressLine1, ...addressLine2] = assigned_request.service_request_object.full_address.split(',');
 
@@ -86,24 +86,23 @@ const buildDispatchResolutionsDoc = (drs = []) => {
       });
 
       // Animal count
-      pdf.drawSectionHeader({ text: 'Animals', fontSize: 12 });
+      pdf.drawSectionHeader({ text: 'Animals', fontSize: 14 });
 
       const assignedRequestAnimals =
         assigned_request.service_request_object.animals.filter((animal) =>
           Object.keys(assigned_request.animals).includes(String(animal.id))
         );
 
-      pdf.setDocumentFontSize({ size: 10 });
-      buildAnimalCountList(pdf, assignedRequestAnimals, { countLabelMarginTop: -10 });
+      pdf.setDocumentFontSize({ size: 12 });
+      buildAnimalCountList(pdf, assignedRequestAnimals, { countLabelMarginTop: -12 });
 
       // rest document font size
       pdf.setDocumentFontSize();
 
-      pdf.drawPad(15);
+      pdf.drawPad(10);
     });
 
-    // end of summary page break
-    pdf.drawPageBreak();
+    // end of summary
 
     // loop through SR's and page break between each one
     data.assigned_requests.forEach((assigned_request, index) => {


### PR DESCRIPTION
I've made a small change with a big impact regarding whitespace, there was a page break after the summary of each Service Request in a Dispatch Assignment, so I removed that, and tightened it up a little bit and at the same time making the font size of the headers a bit bigger to keep separation of sections. Screenshot comparison below (left: optimized; right: original). This is also very dynamic, but i feel this small change has the most sweeping impact.  If you want me to take it further into the  depths of the document, let me know and I will shrink it more.

[
![Screenshot 2024-06-05 at 9 47 59 PM](https://github.com/trevorskaggs/shelterly/assets/1508574/85a51c99-bdd7-4ab5-bf92-1db5edb623a1)
](url)

Closes #712 