### PR TITLE
776: fixes animal link on MR to use `id_for_incident`

### DIFF
--- a/frontend/src/vet/MedicalRecordDetails.js
+++ b/frontend/src/vet/MedicalRecordDetails.js
@@ -115,7 +115,7 @@ function MedicalRecordDetails({ id, incident, organization }) {
             <ListGroup variant="flush" style={{marginTop:"-13px", marginBottom:"-13px"}}>
               <ListGroup.Item>
                 <div className="row" style={{textTransform:"capitalize"}}>
-                  <span className="col-4"><b>ID:</b> <Link href={"/" + organization + "/" + incident + "/animals/" + data.animal_object.id} className="text-link" style={{textDecoration:"none", color:"white"}}>A#{data.animal_object.id_for_incident}</Link></span>
+                  <span className="col-4"><b>ID:</b> <Link href={"/" + organization + "/" + incident + "/animals/" + data.animal_object.id_for_incident} className="text-link" style={{textDecoration:"none", color:"white"}}>A#{data.animal_object.id_for_incident}</Link></span>
                   <span className="col-4"><b>Species:</b> {data.animal_object.species_string}</span>
                   <span className="col-4"><b>Age:</b> {data.animal_object.age||"Unknown"}</span>
                 </div>


### PR DESCRIPTION
Fixes the animal link on the Medical Record (MR) Details to reference the `id_for_incident` property of the animal instead of the PK.

The medical record is fixed as requested by issue #776, however the same behavior exists on the Patient card component, which is present on the following pages:

- Diagnosis Form
- Diagnosis Results Form
- Exam Form
- Orders Form
- Procedure Results Form
- Treatment Plan Form
- Treatment Request Form

Should I apply the same fix to the Patient card component?


> Note: In my own testing I could not get the two numbers (`id` vs `id_for_incident`) to diverge, so technically I was unable to fully e2e test this, however, given the simple edit needed I figured that would be fine, and whoever reviews this would know how to test it proper. Let me know if I missed something.


Closes #776 