### PR TITLE
774: Fix QR code link on animal care schedules

### DIFF
--- a/frontend/src/animals/AnimalDetails.js
+++ b/frontend/src/animals/AnimalDetails.js
@@ -128,7 +128,7 @@ function AnimalDetails({ id, incident, organization }) {
 
   const handleDownloadPdfClick = async () => {
     setIsLoading(true);
-    const pageURL = getFullLocationFromPath(`/${organization}/${incident}/animals/${id}`);
+    const pageURL = getFullLocationFromPath(`/${organization}/${incident}/animals/${data.id_for_incident}`);
     // wait for 1 tick so spinner will set before the print button locks up the browser
     await new Promise(resolve => setTimeout(resolve, 0));
     printAnimalCareSchedule({ ...data, url: pageURL })

--- a/frontend/src/animals/AnimalSearch.js
+++ b/frontend/src/animals/AnimalSearch.js
@@ -164,7 +164,7 @@ function AnimalSearch({ incident, organization }) {
   };
 
   function buildAnimalUrl(animal) {
-    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id}`)
+    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id_for_incident}`)
   }
 
   const handleDownloadPdfClick = (animalId) => {
@@ -177,7 +177,7 @@ function AnimalSearch({ incident, organization }) {
     e.preventDefault();
 
     handleSubmitting()
-      .then(() => data.animals.filter(animal => animals.includes(animal.id)).map((animal) => ({
+      .then(() => data.animals.filter(animal => animals.includes(animal.id_for_incident)).map((animal) => ({
         ...animal,
         url: buildAnimalUrl(animal)
       })))

--- a/frontend/src/hotline/ServiceRequestDetails.js
+++ b/frontend/src/hotline/ServiceRequestDetails.js
@@ -102,7 +102,7 @@ function ServiceRequestDetails({ id, incident, organization }) {
   }
 
   function buildAnimalUrl(animal) {
-    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id}`)
+    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id_for_incident}`)
   }
 
   const handleDownloadPdfClick = async () => {

--- a/frontend/src/people/PersonDetails.js
+++ b/frontend/src/people/PersonDetails.js
@@ -75,7 +75,7 @@ function PersonDetails({id, incident, organization}) {
 
   function buildAnimalUrl(animal) {
     return getFullLocationFromPath(
-      `/${organization}/${incident}/animals/${animal.id}`
+      `/${organization}/${incident}/animals/${animal.id_for_incident}`
     );
   }
 

--- a/frontend/src/shelter/RoomDetails.js
+++ b/frontend/src/shelter/RoomDetails.js
@@ -14,10 +14,12 @@ import AnimalCards from '../components/AnimalCards';
 import { SystemErrorContext } from '../components/SystemError';
 import ShelterlyPrintifyButton from '../components/ShelterlyPrintifyButton';
 import { printRoomAnimalCareSchedules } from './Utils';
+import { useLocationWithRoutes } from '../hooks';
 
 function RoomDetails({ id, incident, organization }) {
 
   const { setShowSystemError } = useContext(SystemErrorContext);
+  const { getFullLocationFromPath } = useLocationWithRoutes();
 
   const [data, setData] = useState({name:'', description:'', building:null, building_name: '', shelter_name:'', shelter: null, animals:[], action_history:[]});
   const [showModal, setShowModal] = useState(false);
@@ -31,8 +33,15 @@ function RoomDetails({ id, incident, organization }) {
     });
   }
 
+  function buildAnimalUrl(animal) {
+    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id_for_incident}`)
+  }
+
   const handlePrintAllAnimalsClick = () =>
-    printRoomAnimalCareSchedules(data.animals, id)
+    printRoomAnimalCareSchedules(data.animals.map((animal) => ({
+      ...animal,
+      url: buildAnimalUrl(animal)
+    })), id)
 
   // Hook for initializing data.
   useEffect(() => {

--- a/frontend/src/shelter/ShelterIntakeSummary.js
+++ b/frontend/src/shelter/ShelterIntakeSummary.js
@@ -42,7 +42,7 @@ function ShelterIntakeSummary({ id, incident, organization }) {
   const { getFullLocationFromPath } = useLocationWithRoutes();
 
   function buildAnimalUrl(animal) {
-    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id}`)
+    return getFullLocationFromPath(`/${organization}/${incident}/animals/${animal.id_for_incident}`)
   }
 
   const handlePrintOwnerClick = () =>


### PR DESCRIPTION
fixes qr code on all animal care schedules to use `id_for_incident` a

adds qr code to Shelter->Room Details print care schedules

Closes #774 