### PR TITLE
775: fixed precision length (6) on address lookup lat/lon

### DIFF
--- a/frontend/src/components/Form.js
+++ b/frontend/src/components/Form.js
@@ -560,8 +560,8 @@ const AddressLookup = ({setLatLon, ...props}) => {
       setFieldValue("city", components.locality || '');
       setFieldValue("state", components.administrative_area_level_1);
       setFieldValue("zip_code", components.postal_code);
-      setFieldValue("latitude", suggestion.geometry.location.lat());
-      setFieldValue("longitude", suggestion.geometry.location.lng());
+      setFieldValue("latitude", suggestion.geometry.location.lat().toFixed(6));
+      setFieldValue("longitude", suggestion.geometry.location.lng().toFixed(6));
       setFieldValue("full_address", suggestion.formatted_address.replace(', USA', '').replace(', United States', '').replace(', Canada', ''));
       setLatLon(suggestion.geometry.location.lat(), suggestion.geometry.location.lng());
       setSearch({});


### PR DESCRIPTION
The precision restriction is at the model level

/animals/migrations/0001_initial.py: (lines 27-28)

```python
('latitude', models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True)),
('longitude', models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True)),
```

I'd rather not change it there, instead just added  `.toFixed(6)` before it sends the lat/lon as formData to the api, and that works.

Closes #775 