### PR TITLE
#723: Default team name option for preplanned

### DIFF
--- a/evac/migrations/0024_dispatchteam_default_name.py
+++ b/evac/migrations/0024_dispatchteam_default_name.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('evac', '0023_populate_id_for_incident'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='dispatchteam',
+            name='default_name',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/evac/models.py
+++ b/evac/models.py
@@ -26,6 +26,7 @@ class DispatchTeam(models.Model):
     dispatch_date = models.DateTimeField(auto_now_add=True)
     show = models.BooleanField(default=True)
     incident = models.ForeignKey(Incident, on_delete=models.CASCADE)
+    default_name = models.BooleanField(default=False)
 
     def __str__(self):
         return self.name

--- a/evac/serializers.py
+++ b/evac/serializers.py
@@ -36,6 +36,7 @@ class DispatchTeamSerializer(serializers.ModelSerializer):
     team_member_objects = EvacTeamMemberSerializer(source='team_members', required=False, read_only=True, many=True)
     display_name = serializers.SerializerMethodField()
     is_assigned = serializers.BooleanField(read_only=True)
+    default_name = serializers.BooleanField()
 
     # Custom field for Name Output
     def get_display_name(self, obj):

--- a/frontend/src/dispatch/DispatchSummary.js
+++ b/frontend/src/dispatch/DispatchSummary.js
@@ -57,10 +57,10 @@ function DispatchSummary({ id, incident, organization }) {
   const [isPreplanned, setIsPreplanned] = useState(false);
 
   const handleTeamNameSubmit = async () => {
-    let requestBody;
+    const requestBody = {};
 
-    if (defaultTeamName) {
-      requestBody = { defaultName: true };
+    if (defaultTeamName === true || defaultTeamName === false) {
+      requestBody.defaultName = defaultTeamName;
     } else {
       if (teamName.replace(/ /g, '').length === 0) {
         setError("Team name cannot be blank.");
@@ -71,7 +71,7 @@ function DispatchSummary({ id, incident, organization }) {
         return;
       }
 
-      requestBody = { name: teamName };
+      requestBody.name = teamName;
     }
 
     setIsLoading(true);
@@ -144,6 +144,7 @@ function DispatchSummary({ id, incident, organization }) {
     .then(response => {
       setData(prevState => ({ ...prevState, "team_member_objects":response.data.team_member_objects, "team_members":response.data.team_members }));
       setTeamData(prevState => ({ ...prevState, "options":prevState.options.filter(option => !response.data.team_members.includes(option.id)) }));
+      setTeamName(response.data.name)
       setTeamMembers([]);
       handleClose();
     })
@@ -202,6 +203,7 @@ function DispatchSummary({ id, incident, organization }) {
           setMapState(map_dict);
           setTeamData({teams: [], options: [], isFetching: true});
           setTeamName(response.data.team_object.name);
+          setDefaultTeamName(response.data.team_object.default_name === true);
           setIsPreplanned(response.data.team_name.match(/^Preplanned [0-9]+$/));
           axios.get('/evac/api/evacteammember/?incident=' + incident + '&organization=' + organization +'&training=' + state.incident.training, {
             cancelToken: source.token,
@@ -273,7 +275,7 @@ function DispatchSummary({ id, incident, organization }) {
           <Card.Body>
             <div className="d-flex justify-content-between">
               <h4 className="h5 mb-0 pb-0 pt-2">
-                {data.team_object ? data.team_object.name : "Preplanned"}
+                {teamName ? teamName : data.team_object ? data.team_object.name : "Preplanned"}
                 <OverlayTrigger
                   key={"edit-team-name"}
                   placement="top"


### PR DESCRIPTION
- adds default_name boolean field to dispatchteam
- increments team N if default_team is true for preplanned

### Testing step-by-step

> before running the server locally, do a migrate

1. login, select org, incident
2. create hotline requests a plenty
3. deploy some teams
4. preplan some assignments
5. mess around with the teams to get the numbers as funky as you want
6. go to a preplanned assignment
7. click edit team name
8. check default name
9. save
10. click add team member, and add someone
11. default name should be Team N where N is lowest available number from the pool of active Team N's

> Repeat steps 3-11 as crazy as you can to find a bug